### PR TITLE
Pass map of input topic to KStream objects. 

### DIFF
--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     api("com.typesafe:config:1.4.0")
     api("io.confluent:kafka-avro-serializer:5.5.0")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.13")
-    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.5")
+    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.9")
     implementation("org.apache.kafka:kafka-clients:5.5.1-ccs")
     testImplementation("org.apache.kafka:kafka-streams-test-utils:5.5.1-ccs")
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -60,7 +60,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
       );
     } catch (Exception e) {
       getLogger().error("Error initializing - ", e);
-      throw new RuntimeException(e);
+      e.printStackTrace();
+      System.exit(1);
     }
   }
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -2,72 +2,93 @@ package org.hypertrace.core.kafkastreams.framework;
 
 import com.typesafe.config.Config;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateListener;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateRestoreListener;
 import org.hypertrace.core.kafkastreams.framework.util.ExceptionUtils;
-import org.hypertrace.core.serviceframework.background.PlatformBackgroundJob;
+import org.hypertrace.core.serviceframework.PlatformService;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
 import org.hypertrace.core.serviceframework.config.ConfigUtils;
 import org.slf4j.Logger;
 
-/**
- * Abstract base class that all Kafka Streams based applications need to extend
- */
-public abstract class KafkaStreamsApp implements PlatformBackgroundJob {
+public abstract class KafkaStreamsApp extends PlatformService {
 
   public static final String CLEANUP_LOCAL_STATE = "cleanup.local.state";
+  protected KafkaStreams app;
 
-  protected final KafkaStreams app;
+  public KafkaStreamsApp(ConfigClient configClient) {
+    super(configClient);
+  }
 
-  protected KafkaStreamsApp(Config jobConfig) {
-    Properties streamsConfig = getStreamsConfig(jobConfig);
-    getLogger().info(ConfigUtils.propertiesAsList(streamsConfig));
+  @Override
+  protected void doInit() {
+    try {
+      Properties streamsConfig = getStreamsConfig(getAppConfig());
+      getLogger().info(ConfigUtils.propertiesAsList(streamsConfig));
 
-    StreamsBuilder streamsBuilder = new StreamsBuilder();
-    streamsBuilder = buildTopology(streamsConfig, streamsBuilder);
-    Topology topology = streamsBuilder.build();
-    getLogger().info(topology.describe().toString());
+      Map<String, KStream<?, ?>> sourceStreams = new HashMap<>();
+      StreamsBuilder streamsBuilder = new StreamsBuilder();
+      streamsBuilder = buildTopology(streamsConfig, streamsBuilder, sourceStreams);
+      Topology topology = streamsBuilder.build();
+      getLogger().info(topology.describe().toString());
 
-    app = new KafkaStreams(topology, streamsConfig);
+      app = new KafkaStreams(topology, streamsConfig);
 
-    // useful for resetting local state - during testing or any other scenarios where
-    // state (rocksdb) needs to be reset
-    if (streamsConfig.containsKey(CLEANUP_LOCAL_STATE)) {
-      boolean cleanup = Boolean.parseBoolean((String) streamsConfig.get(CLEANUP_LOCAL_STATE));
-      if (cleanup) {
-        getLogger().info("=== Resetting local state ===");
-        app.cleanUp();
-      }
-    }
-
-    app.setStateListener(new LoggingStateListener(app));
-    app.setGlobalStateRestoreListener(new LoggingStateRestoreListener());
-    app.setUncaughtExceptionHandler((thread, exception) -> {
-          getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
-              ExceptionUtils.getStackTrace(exception));
-          System.exit(1);
+      // useful for resetting local state - during testing or any other scenarios where
+      // state (rocksdb) needs to be reset
+      if (streamsConfig.containsKey(CLEANUP_LOCAL_STATE)) {
+        boolean cleanup = Boolean.parseBoolean((String) streamsConfig.get(CLEANUP_LOCAL_STATE));
+        if (cleanup) {
+          getLogger().info("=== Resetting local state ===");
+          app.cleanUp();
         }
-    );
+      }
+
+      app.setStateListener(new LoggingStateListener(app));
+      app.setGlobalStateRestoreListener(new LoggingStateRestoreListener());
+      app.setUncaughtExceptionHandler((thread, exception) -> {
+            getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
+                ExceptionUtils.getStackTrace(exception));
+            System.exit(1);
+          }
+      );
+    } catch (Exception e) {
+      getLogger().error("Error initializing - ", e);
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
-  public void run() throws Exception {
-    app.start();
+  protected void doStart() {
+    try {
+      app.start();
+    } catch (Exception e) {
+      getLogger().error("Error starting - ", e);
+      e.printStackTrace();
+      System.exit(1);
+    }
   }
 
   @Override
-  public void stop() {
-    // Refer to https://issues.apache.org/jira/browse/KAFKA-4366 for why
-    // a timeout is needed
+  protected void doStop() {
     app.close(Duration.ofSeconds(30));
   }
 
-  protected abstract StreamsBuilder buildTopology(Properties streamsConfig, StreamsBuilder streamsBuilder);
+  @Override
+  public boolean healthCheck() {
+    return true;
+  }
 
-  protected abstract Properties getStreamsConfig(Config jobConfig);
+  public abstract StreamsBuilder buildTopology(Properties streamsConfig,
+      StreamsBuilder streamsBuilder, Map<String, KStream<?, ?>> sourceStreams);
 
-  protected abstract Logger getLogger();
+  public abstract Properties getStreamsConfig(Config jobConfig);
+
+  public abstract Logger getLogger();
 }

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -2,11 +2,13 @@ package org.hypertrace.core.kafkastreams.framework;
 
 
 import com.typesafe.config.Config;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
 import org.slf4j.Logger;
 
 public class SampleApp extends KafkaStreamsApp {
@@ -15,17 +17,18 @@ public class SampleApp extends KafkaStreamsApp {
   static String OUTPUT_TOPIC = "output";
   static final String APP_ID = "testapp";
 
-  protected SampleApp(Config jobConfig) {
-    super(jobConfig);
+  public SampleApp(ConfigClient configClient) {
+    super(configClient);
   }
 
   @Override
-  protected StreamsBuilder buildTopology(Properties streamsConfig, StreamsBuilder streamsBuilder) {
+  public StreamsBuilder buildTopology(Properties streamsConfig, StreamsBuilder streamsBuilder,
+      Map<String, KStream<?, ?>> sourceStreams) {
     return retainWordsLongerThan5Letters(streamsBuilder);
   }
 
   @Override
-  protected Properties getStreamsConfig(Config jobConfig) {
+  public Properties getStreamsConfig(Config jobConfig) {
     Properties config = new Properties();
     config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
     config.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
@@ -37,7 +40,7 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  protected Logger getLogger() {
+  public Logger getLogger() {
     return null;
   }
 


### PR DESCRIPTION
This is useful to merge topologies across jobs
The map could be used to check if an input source node already exists and re-use as only one source node for a topic can exist.