### PR TITLE
Adds supports for creating input/output topics

### DIFF
--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     api("com.typesafe:config:1.4.0")
     api("io.confluent:kafka-avro-serializer:5.5.0")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.13")
-    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.5")
+    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.9")
     implementation("org.apache.kafka:kafka-clients:5.5.1-ccs")
     testImplementation("org.apache.kafka:kafka-streams-test-utils:5.5.1-ccs")
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -53,9 +53,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
       getLogger().info(ConfigUtils.propertiesAsList(properties));
 
       // get the lists of all input and output topics to pre create if any
-      boolean precreateTopics = getAppConfig().hasPath(PRE_CREATE_TOPICS) && Boolean
-          .parseBoolean(getAppConfig().getString(PRE_CREATE_TOPICS));
-      if (precreateTopics) {
+      if (getAppConfig().hasPath(PRE_CREATE_TOPICS) &&
+          getAppConfig().getBoolean(PRE_CREATE_TOPICS)) {
         List<String> topics = Streams.concat(
             getInputTopics().stream(),
             getOutputTopics().stream()

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -53,16 +53,17 @@ public abstract class KafkaStreamsApp extends PlatformService {
       getLogger().info(ConfigUtils.propertiesAsList(properties));
 
       // get the lists of all input and output topics to pre create if any
-      boolean createTopic = getAppConfig().hasPath(PRE_CREATE_TOPICS) && Boolean.parseBoolean(getAppConfig().getString(PRE_CREATE_TOPICS));
+      boolean createTopic = getAppConfig().hasPath(PRE_CREATE_TOPICS) && Boolean
+          .parseBoolean(getAppConfig().getString(PRE_CREATE_TOPICS));
       if (createTopic) {
         List<String> topics = Streams.concat(
-                getInputTopics().stream(),
-                getOutputTopics().stream()
+            getInputTopics().stream(),
+            getOutputTopics().stream()
         ).collect(Collectors.toList());
 
         KafkaTopicCreator.createTopics(properties.getProperty(
-                CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, ""),
-                topics);
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, ""),
+            topics);
       }
 
       Map<String, KStream<?, ?>> sourceStreams = new HashMap<>();
@@ -86,10 +87,10 @@ public abstract class KafkaStreamsApp extends PlatformService {
       app.setStateListener(new LoggingStateListener(app));
       app.setGlobalStateRestoreListener(new LoggingStateRestoreListener());
       app.setUncaughtExceptionHandler((thread, exception) -> {
-                getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
-                        ExceptionUtils.getStackTrace(exception));
-                System.exit(1);
-              }
+            getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
+                ExceptionUtils.getStackTrace(exception));
+            System.exit(1);
+          }
       );
     } catch (Exception e) {
       getLogger().error("Error initializing - ", e);
@@ -125,17 +126,17 @@ public abstract class KafkaStreamsApp extends PlatformService {
   public Map<String, Object> getBaseStreamsConfig() {
     Map<String, Object> baseStreamsConfig = new HashMap<>();
     baseStreamsConfig.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
-            UseWallclockTimeOnInvalidTimestamp.class);
+        UseWallclockTimeOnInvalidTimestamp.class);
     baseStreamsConfig.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
-            LogAndContinueExceptionHandler.class);
+        LogAndContinueExceptionHandler.class);
 
     baseStreamsConfig.put(JOB_CONFIG, getAppConfig());
     return baseStreamsConfig;
   }
 
   public abstract StreamsBuilder buildTopology(Map<String, Object> streamsConfig,
-                                               StreamsBuilder streamsBuilder,
-                                               Map<String, KStream<?, ?>> sourceStreams);
+      StreamsBuilder streamsBuilder,
+      Map<String, KStream<?, ?>> sourceStreams);
 
   public abstract Map<String, Object> getStreamsConfig(Config jobConfig);
 
@@ -149,7 +150,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
    * Merge the props into baseProps
    */
   private Map<String, Object> mergeProperties(Map<String, Object> baseProps,
-                                              Map<String, Object> props) {
+      Map<String, Object> props) {
     props.forEach(baseProps::put);
     return baseProps;
   }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -55,7 +55,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
       // get the lists of all input and output topics to pre create if any
       boolean precreateTopics = getAppConfig().hasPath(PRE_CREATE_TOPICS) && Boolean
           .parseBoolean(getAppConfig().getString(PRE_CREATE_TOPICS));
-      if (createTopic) {
+      if (precreateTopics) {
         List<String> topics = Streams.concat(
             getInputTopics().stream(),
             getOutputTopics().stream()

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -60,7 +60,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
       );
     } catch (Exception e) {
       getLogger().error("Error initializing - ", e);
-      throw new RuntimeException(e);
+      e.printStackTrace();
+      System.exit(1);
     }
   }
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -3,8 +3,6 @@ package org.hypertrace.core.kafkastreams.framework;
 import com.google.common.collect.Streams;
 import com.typesafe.config.Config;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,11 +40,11 @@ public abstract class KafkaStreamsApp extends PlatformService {
 
       // get the lists of all input and output topics to pre create if any
       boolean createTopic = Boolean.parseBoolean(
-              (String) streamsConfig.getOrDefault(PRE_CREATE_TOPICS, false));
+              (String) streamsConfig.getOrDefault(PRE_CREATE_TOPICS, "false"));
       if (createTopic) {
         List<String> topics = Streams.concat(
-                getInputTopics().stream(),
-                getOutputTopics().stream()
+                getInputTopics(streamsConfig).stream(),
+                getOutputTopics(streamsConfig).stream()
         ).collect(Collectors.toList());
 
         KafkaTopicCreator.createTopics(streamsConfig.getProperty(
@@ -76,10 +74,10 @@ public abstract class KafkaStreamsApp extends PlatformService {
       app.setStateListener(new LoggingStateListener(app));
       app.setGlobalStateRestoreListener(new LoggingStateRestoreListener());
       app.setUncaughtExceptionHandler((thread, exception) -> {
-            getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
-                ExceptionUtils.getStackTrace(exception));
-            System.exit(1);
-          }
+                getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
+                        ExceptionUtils.getStackTrace(exception));
+                System.exit(1);
+              }
       );
     } catch (Exception e) {
       getLogger().error("Error initializing - ", e);
@@ -110,13 +108,14 @@ public abstract class KafkaStreamsApp extends PlatformService {
   }
 
   public abstract StreamsBuilder buildTopology(Properties streamsConfig,
-      StreamsBuilder streamsBuilder, Map<String, KStream<?, ?>> sourceStreams);
+                                               StreamsBuilder streamsBuilder, Map<String, KStream<?, ?>> sourceStreams);
 
   public abstract Properties getStreamsConfig(Config jobConfig);
 
   public abstract Logger getLogger();
 
-  public abstract List<String> getInputTopics();
-  public abstract List<String> getOutputTopics();
+  public abstract List<String> getInputTopics(Properties streamsConfig);
+
+  public abstract List<String> getOutputTopics(Properties streamsConfig);
 
 }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -134,7 +134,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
   }
 
   public abstract StreamsBuilder buildTopology(Map<String, Object> streamsConfig,
-                                               StreamsBuilder streamsBuilder, Map<String, KStream<?, ?>> sourceStreams);
+                                               StreamsBuilder streamsBuilder,
+                                               Map<String, KStream<?, ?>> sourceStreams);
 
   public abstract Map<String, Object> getStreamsConfig(Config jobConfig);
 
@@ -147,7 +148,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
   /**
    * Merge the props into baseProps
    */
-  private Map<String, Object> mergeProperties(Map<String, Object> baseProps, Map<String, Object> props) {
+  private Map<String, Object> mergeProperties(Map<String, Object> baseProps,
+                                              Map<String, Object> props) {
     props.forEach(baseProps::put);
     return baseProps;
   }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -2,72 +2,93 @@ package org.hypertrace.core.kafkastreams.framework;
 
 import com.typesafe.config.Config;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateListener;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateRestoreListener;
 import org.hypertrace.core.kafkastreams.framework.util.ExceptionUtils;
-import org.hypertrace.core.serviceframework.background.PlatformBackgroundJob;
+import org.hypertrace.core.serviceframework.PlatformService;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
 import org.hypertrace.core.serviceframework.config.ConfigUtils;
 import org.slf4j.Logger;
 
-/**
- * Abstract base class that all Kafka Streams based applications need to extend
- */
-public abstract class KafkaStreamsApp implements PlatformBackgroundJob {
+public abstract class KafkaStreamsApp extends PlatformService {
 
   public static final String CLEANUP_LOCAL_STATE = "cleanup.local.state";
+  protected KafkaStreams app;
 
-  protected final KafkaStreams app;
+  public KafkaStreamsApp(ConfigClient configClient) {
+    super(configClient);
+  }
 
-  protected KafkaStreamsApp(Config jobConfig) {
-    Properties streamsConfig = getStreamsConfig(jobConfig);
-    getLogger().info(ConfigUtils.propertiesAsList(streamsConfig));
+  @Override
+  protected void doInit() {
+    try {
+      Properties streamsConfig = getStreamsConfig(getAppConfig());
+      getLogger().info(ConfigUtils.propertiesAsList(streamsConfig));
 
-    StreamsBuilder streamsBuilder = new StreamsBuilder();
-    streamsBuilder = buildTopology(streamsConfig, streamsBuilder);
-    Topology topology = streamsBuilder.build();
-    getLogger().info(topology.describe().toString());
+      Map<String, KStream<?, ?>> sourceStreams = new HashMap<>();
+      StreamsBuilder streamsBuilder = new StreamsBuilder();
+      streamsBuilder = buildTopology(streamsConfig, streamsBuilder, sourceStreams);
+      Topology topology = streamsBuilder.build();
+      getLogger().info(topology.describe().toString());
 
-    app = new KafkaStreams(topology, streamsConfig);
+      app = new KafkaStreams(topology, streamsConfig);
 
-    // useful for resetting local state - during testing or any other scenarios where
-    // state (rocksdb) needs to be reset
-    if (streamsConfig.containsKey(CLEANUP_LOCAL_STATE)) {
-      boolean cleanup = Boolean.parseBoolean((String) streamsConfig.get(CLEANUP_LOCAL_STATE));
-      if (cleanup) {
-        getLogger().info("=== Resetting local state ===");
-        app.cleanUp();
-      }
-    }
-
-    app.setStateListener(new LoggingStateListener(app));
-    app.setGlobalStateRestoreListener(new LoggingStateRestoreListener());
-    app.setUncaughtExceptionHandler((thread, exception) -> {
-          getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
-              ExceptionUtils.getStackTrace(exception));
-          System.exit(1);
+      // useful for resetting local state - during testing or any other scenarios where
+      // state (rocksdb) needs to be reset
+      if (streamsConfig.containsKey(CLEANUP_LOCAL_STATE)) {
+        boolean cleanup = Boolean.parseBoolean((String) streamsConfig.get(CLEANUP_LOCAL_STATE));
+        if (cleanup) {
+          getLogger().info("=== Resetting local state ===");
+          app.cleanUp();
         }
-    );
+      }
+
+      app.setStateListener(new LoggingStateListener(app));
+      app.setGlobalStateRestoreListener(new LoggingStateRestoreListener());
+      app.setUncaughtExceptionHandler((thread, exception) -> {
+            getLogger().error("Thread=[{}] encountered=[{}]. Will exit.", thread.getName(),
+                ExceptionUtils.getStackTrace(exception));
+            System.exit(1);
+          }
+      );
+    } catch (Exception e) {
+      getLogger().error("Error initializing - ", e);
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
-  public void run() throws Exception {
-    app.start();
+  protected void doStart() {
+    try {
+      app.start();
+    } catch (Exception e) {
+      getLogger().error("Error starting - ", e);
+      e.printStackTrace();
+      System.exit(1);
+    }
   }
 
   @Override
-  public void stop() {
-    // Refer to https://issues.apache.org/jira/browse/KAFKA-4366 for why
-    // a timeout is needed
+  protected void doStop() {
     app.close(Duration.ofSeconds(30));
   }
 
-  protected abstract StreamsBuilder buildTopology(Properties streamsConfig, StreamsBuilder streamsBuilder);
+  @Override
+  public boolean healthCheck() {
+    return true;
+  }
 
-  protected abstract Properties getStreamsConfig(Config jobConfig);
+  public abstract StreamsBuilder buildTopology(Properties streamsConfig,
+      StreamsBuilder streamsBuilder, Map<String, KStream<?, ?>> sourceStreams);
 
-  protected abstract Logger getLogger();
+  public abstract Properties getStreamsConfig(Config jobConfig);
+
+  public abstract Logger getLogger();
 }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -53,7 +53,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
       getLogger().info(ConfigUtils.propertiesAsList(properties));
 
       // get the lists of all input and output topics to pre create if any
-      boolean createTopic = getAppConfig().hasPath(PRE_CREATE_TOPICS) && Boolean
+      boolean precreateTopics = getAppConfig().hasPath(PRE_CREATE_TOPICS) && Boolean
           .parseBoolean(getAppConfig().getString(PRE_CREATE_TOPICS));
       if (createTopic) {
         List<String> topics = Streams.concat(

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/topics/creator/KafkaTopicCreator.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/topics/creator/KafkaTopicCreator.java
@@ -1,0 +1,51 @@
+package org.hypertrace.core.kafkastreams.framework.topics.creator;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.streams.StreamsConfig;
+import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class for creating required topics before starting streaming application
+ * */
+public class KafkaTopicCreator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaTopicCreator.class);
+
+
+  private static final int numPartitions = 1;
+  private static final short numReplications = 1;
+
+  public static void createTopics(String bootstrapServers, List<String> topics) {
+    LOGGER.info("Creating topics : {}", topics);
+
+    Properties adminProps = new Properties();
+    adminProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    adminProps.put(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG, 5000);
+
+    AdminClient client = AdminClient.create(adminProps);
+
+    List<NewTopic> newTopics = topics.stream().
+            map(topic -> new NewTopic(topic, numPartitions, numReplications))
+            .collect(Collectors.toList());
+
+    CreateTopicsResult result = client.createTopics(newTopics);
+
+    try {
+      result.all().get();
+      LOGGER.info("Successfully created all topics : {}", topics);
+    } catch (InterruptedException | ExecutionException e) {
+      throw new IllegalStateException(e);
+    } finally {
+      client.close();
+    }
+  }
+
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -2,6 +2,9 @@ package org.hypertrace.core.kafkastreams.framework;
 
 
 import com.typesafe.config.Config;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
@@ -43,6 +46,22 @@ public class SampleApp extends KafkaStreamsApp {
   public Logger getLogger() {
     return null;
   }
+
+  @Override
+  public List<String> getInputTopics() {
+    return Arrays.asList(INPUT_TOPIC);
+  }
+
+  @Override
+  public List<String> getOutputTopics() {
+    return Arrays.asList(OUTPUT_TOPIC);
+  }
+
+  @Override
+  public String getServiceName() {
+    return "SampleApp";
+  }
+
 
   static StreamsBuilder retainWordsLongerThan5Letters(StreamsBuilder streamsBuilder) {
     KStream<String, String> stream = streamsBuilder.stream(INPUT_TOPIC);

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -2,11 +2,13 @@ package org.hypertrace.core.kafkastreams.framework;
 
 
 import com.typesafe.config.Config;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
 import org.slf4j.Logger;
 
 public class SampleApp extends KafkaStreamsApp {
@@ -15,17 +17,18 @@ public class SampleApp extends KafkaStreamsApp {
   static String OUTPUT_TOPIC = "output";
   static final String APP_ID = "testapp";
 
-  protected SampleApp(Config jobConfig) {
-    super(jobConfig);
+  public SampleApp(ConfigClient configClient) {
+    super(configClient);
   }
 
   @Override
-  protected StreamsBuilder buildTopology(Properties streamsConfig, StreamsBuilder streamsBuilder) {
+  public StreamsBuilder buildTopology(Properties streamsConfig, StreamsBuilder streamsBuilder,
+      Map<String, KStream<?, ?>> sourceStreams) {
     return retainWordsLongerThan5Letters(streamsBuilder);
   }
 
   @Override
-  protected Properties getStreamsConfig(Config jobConfig) {
+  public Properties getStreamsConfig(Config jobConfig) {
     Properties config = new Properties();
     config.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
     config.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
@@ -37,7 +40,7 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  protected Logger getLogger() {
+  public Logger getLogger() {
     return null;
   }
 

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -31,8 +31,9 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public StreamsBuilder buildTopology(Map<String, Object> streamsConfig, StreamsBuilder streamsBuilder,
-                                      Map<String, KStream<?, ?>> sourceStreams) {
+  public StreamsBuilder buildTopology(Map<String, Object> streamsConfig,
+      StreamsBuilder streamsBuilder,
+      Map<String, KStream<?, ?>> sourceStreams) {
     return retainWordsLongerThan5Letters(streamsBuilder);
   }
 
@@ -42,9 +43,9 @@ public class SampleApp extends KafkaStreamsApp {
     config.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
     config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
     config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG,
-            Serdes.String().getClass().getName());
+        Serdes.String().getClass().getName());
     config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG,
-            Serdes.String().getClass().getName());
+        Serdes.String().getClass().getName());
     return config;
   }
 

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -48,12 +48,12 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public List<String> getInputTopics() {
+  public List<String> getInputTopics(Properties streamsConfig) {
     return Arrays.asList(INPUT_TOPIC);
   }
 
   @Override
-  public List<String> getOutputTopics() {
+  public List<String> getOutputTopics(Properties streamsConfig) {
     return Arrays.asList(OUTPUT_TOPIC);
   }
 


### PR DESCRIPTION
As we observed that we need to pre-create required user level topics before starting kafka stream application, this PR provides a way for creating them.

- the functionality will be driven by property `precreate.topics`
- the above will be exposed as ENV as well so, this will help in enabling different deployment mode
- Using helm, we can still choose to used kafka-creator-job using helm pre-install-hook
- Using docker-compose, we will be able to create them by adding the environ property as below

```   
environment:
      - PRE_CREATE_TOPICS=true
```

More details on the issue - https://github.com/hypertrace/kafka-streams-framework/issues/5