### PR TITLE
Adding support for jobs to adds its own configs

### DIFF
--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -15,7 +15,6 @@ import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CON
 import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION;
 import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
 import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
-import static org.hypertrace.core.kafkastreams.framework.constants.KafkaStreamsAppConstants.JOB_CONFIG;
 
 import com.google.common.collect.Streams;
 import com.typesafe.config.Config;
@@ -58,9 +57,10 @@ public abstract class KafkaStreamsApp extends PlatformService {
   protected void doInit() {
     try {
       Map<String, Object> baseStreamsConfig = getBaseStreamsConfig();
-      Map<String, Object> streamsConfig = getStreamsConfig(new HashMap<>(), getAppConfig());
+      Map<String, Object> streamsConfig = getStreamsConfig(getAppConfig());
 
       Map<String, Object> mergedProperties = mergeProperties(baseStreamsConfig, streamsConfig);
+      mergedProperties = additionalJobConfig(mergedProperties);
 
       Properties properties = new Properties();
       properties.putAll(mergedProperties);
@@ -170,7 +170,9 @@ public abstract class KafkaStreamsApp extends PlatformService {
       StreamsBuilder streamsBuilder,
       Map<String, KStream<?, ?>> sourceStreams);
 
-  public abstract Map<String, Object> getStreamsConfig(Map<String, Object> properties, Config jobConfig);
+  public abstract Map<String, Object> getStreamsConfig(Config jobConfig);
+
+  public abstract Map<String, Object> additionalJobConfig(Map<String, Object> properties);
 
   public abstract Logger getLogger();
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -62,10 +62,6 @@ public abstract class KafkaStreamsApp extends PlatformService {
       Map<String, Object> mergedProperties = mergeProperties(baseStreamsConfig, streamsConfig);
       mergedProperties = additionalJobConfig(mergedProperties, getAppConfig());
 
-      Properties properties = new Properties();
-      properties.putAll(mergedProperties);
-
-      getLogger().info(ConfigUtils.propertiesAsList(properties));
 
       // get the lists of all input and output topics to pre create if any
       if (getAppConfig().hasPath(PRE_CREATE_TOPICS) &&
@@ -75,8 +71,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
             getOutputTopics(mergedProperties).stream()
         ).collect(Collectors.toList());
 
-        KafkaTopicCreator.createTopics(properties.getProperty(
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, ""),
+        KafkaTopicCreator.createTopics((String) mergedProperties.getOrDefault(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, ""),
             topics);
       }
 
@@ -85,6 +80,10 @@ public abstract class KafkaStreamsApp extends PlatformService {
       streamsBuilder = buildTopology(mergedProperties, streamsBuilder, sourceStreams);
       Topology topology = streamsBuilder.build();
       getLogger().info(topology.describe().toString());
+
+      Properties properties = new Properties();
+      properties.putAll(mergedProperties);
+      getLogger().info(ConfigUtils.propertiesAsList(properties));
 
       app = new KafkaStreams(topology, properties);
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -71,8 +71,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
       if (getAppConfig().hasPath(PRE_CREATE_TOPICS) &&
           getAppConfig().getBoolean(PRE_CREATE_TOPICS)) {
         List<String> topics = Streams.concat(
-            getInputTopics().stream(),
-            getOutputTopics().stream()
+            getInputTopics(mergedProperties).stream(),
+            getOutputTopics(mergedProperties).stream()
         ).collect(Collectors.toList());
 
         KafkaTopicCreator.createTopics(properties.getProperty(
@@ -174,9 +174,9 @@ public abstract class KafkaStreamsApp extends PlatformService {
 
   public abstract Logger getLogger();
 
-  public abstract List<String> getInputTopics();
+  public abstract List<String> getInputTopics(Map<String, Object> properties);
 
-  public abstract List<String> getOutputTopics();
+  public abstract List<String> getOutputTopics(Map<String, Object> properties);
 
   /**
    * Merge the props into baseProps

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -58,10 +58,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
     try {
       Map<String, Object> baseStreamsConfig = getBaseStreamsConfig();
       Map<String, Object> streamsConfig = getStreamsConfig(getAppConfig());
-
       Map<String, Object> mergedProperties = mergeProperties(baseStreamsConfig, streamsConfig);
-      mergedProperties = additionalJobConfig(mergedProperties, getAppConfig());
-
 
       // get the lists of all input and output topics to pre create if any
       if (getAppConfig().hasPath(PRE_CREATE_TOPICS) &&
@@ -161,7 +158,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
     baseStreamsConfig.put(consumerPrefix(AUTO_OFFSET_RESET_CONFIG), "latest");
     baseStreamsConfig.put(consumerPrefix(AUTO_COMMIT_INTERVAL_MS_CONFIG), "5000");
 
-    //baseStreamsConfig.put(JOB_CONFIG, getAppConfig());
+    baseStreamsConfig.put(getJobConfigKey(), getAppConfig());
     return baseStreamsConfig;
   }
 
@@ -171,7 +168,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
 
   public abstract Map<String, Object> getStreamsConfig(Config jobConfig);
 
-  public abstract Map<String, Object> additionalJobConfig(Map<String, Object> properties, Config jobConfig);
+  public abstract String getJobConfigKey();
 
   public abstract Logger getLogger();
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -58,7 +58,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
   protected void doInit() {
     try {
       Map<String, Object> baseStreamsConfig = getBaseStreamsConfig();
-      Map<String, Object> streamsConfig = getStreamsConfig(baseStreamsConfig);
+      Map<String, Object> streamsConfig = getStreamsConfig(new HashMap<>(), getAppConfig());
 
       Map<String, Object> mergedProperties = mergeProperties(baseStreamsConfig, streamsConfig);
 
@@ -170,7 +170,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
       StreamsBuilder streamsBuilder,
       Map<String, KStream<?, ?>> sourceStreams);
 
-  public abstract Map<String, Object> getStreamsConfig(Map<String, Object> baseProperties);
+  public abstract Map<String, Object> getStreamsConfig(Map<String, Object> properties, Config jobConfig);
 
   public abstract Logger getLogger();
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -58,7 +58,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
   protected void doInit() {
     try {
       Map<String, Object> baseStreamsConfig = getBaseStreamsConfig();
-      Map<String, Object> streamsConfig = getStreamsConfig(getAppConfig());
+      Map<String, Object> streamsConfig = getStreamsConfig(baseStreamsConfig);
 
       Map<String, Object> mergedProperties = mergeProperties(baseStreamsConfig, streamsConfig);
 
@@ -162,7 +162,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
     baseStreamsConfig.put(consumerPrefix(AUTO_OFFSET_RESET_CONFIG), "latest");
     baseStreamsConfig.put(consumerPrefix(AUTO_COMMIT_INTERVAL_MS_CONFIG), "5000");
 
-    baseStreamsConfig.put(JOB_CONFIG, getAppConfig());
+    //baseStreamsConfig.put(JOB_CONFIG, getAppConfig());
     return baseStreamsConfig;
   }
 
@@ -170,7 +170,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
       StreamsBuilder streamsBuilder,
       Map<String, KStream<?, ?>> sourceStreams);
 
-  public abstract Map<String, Object> getStreamsConfig(Config jobConfig);
+  public abstract Map<String, Object> getStreamsConfig(Map<String, Object> baseProperties);
 
   public abstract Logger getLogger();
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -60,7 +60,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
       Map<String, Object> streamsConfig = getStreamsConfig(getAppConfig());
 
       Map<String, Object> mergedProperties = mergeProperties(baseStreamsConfig, streamsConfig);
-      mergedProperties = additionalJobConfig(mergedProperties);
+      mergedProperties = additionalJobConfig(mergedProperties, getAppConfig());
 
       Properties properties = new Properties();
       properties.putAll(mergedProperties);
@@ -172,7 +172,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
 
   public abstract Map<String, Object> getStreamsConfig(Config jobConfig);
 
-  public abstract Map<String, Object> additionalJobConfig(Map<String, Object> properties);
+  public abstract Map<String, Object> additionalJobConfig(Map<String, Object> properties, Config jobConfig);
 
   public abstract Logger getLogger();
 

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -10,6 +10,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
+import org.hypertrace.core.kafkastreams.framework.constants.KafkaStreamsAppConstants;
 import org.hypertrace.core.serviceframework.config.ConfigClient;
 import org.slf4j.Logger;
 
@@ -50,8 +51,8 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public Map<String, Object> additionalJobConfig(Map<String, Object> properties, Config jobConfig) {
-    return properties;
+  public String getJobConfigKey() {
+    return KafkaStreamsAppConstants.JOB_CONFIG;
   }
 
   @Override

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -55,12 +55,12 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public List<String> getInputTopics() {
+  public List<String> getInputTopics(Map<String, Object> properties) {
     return Arrays.asList(INPUT_TOPIC);
   }
 
   @Override
-  public List<String> getOutputTopics() {
+  public List<String> getOutputTopics(Map<String, Object> properties) {
     return Arrays.asList(OUTPUT_TOPIC);
   }
 

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -38,7 +38,7 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public Map<String, Object> getStreamsConfig(Config jobConfig) {
+  public Map<String, Object> getStreamsConfig(Map<String, Object> jobConfig) {
     Map<String, Object> config = new HashMap<>();
     config.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
     config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -38,7 +38,7 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public Map<String, Object> getStreamsConfig(Map<String, Object> properties, Config jobConfig) {
+  public Map<String, Object> getStreamsConfig(Config jobConfig) {
     Map<String, Object> config = new HashMap<>();
     config.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
     config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
@@ -49,6 +49,10 @@ public class SampleApp extends KafkaStreamsApp {
     return config;
   }
 
+  @Override
+  public Map<String, Object> additionalJobConfig(Map<String, Object> properties) {
+    return properties;
+  }
   @Override
   public Logger getLogger() {
     return null;

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -53,6 +53,7 @@ public class SampleApp extends KafkaStreamsApp {
   public Map<String, Object> additionalJobConfig(Map<String, Object> properties, Config jobConfig) {
     return properties;
   }
+
   @Override
   public Logger getLogger() {
     return null;

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -38,7 +38,7 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public Map<String, Object> getStreamsConfig(Map<String, Object> jobConfig) {
+  public Map<String, Object> getStreamsConfig(Map<String, Object> properties, Config jobConfig) {
     Map<String, Object> config = new HashMap<>();
     config.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
     config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -50,7 +50,7 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  public Map<String, Object> additionalJobConfig(Map<String, Object> properties) {
+  public Map<String, Object> additionalJobConfig(Map<String, Object> properties, Config jobConfig) {
     return properties;
   }
   @Override


### PR DESCRIPTION
As part of providing support for this - https://github.com/hypertrace/hypertrace-ingester/issues/5, we need a way for each participating job to add its own config.

This will provide a way for a job to adds requires configs both in the framework and in ProcessorContext.

