### PR TITLE
Make bounded memory rocksdb config setter as default config setter

### DIFF
--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -39,7 +39,7 @@ import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.kstream.KStream;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateListener;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateRestoreListener;
-import org.hypertrace.core.kafkastreams.framework.rocksdb.RocksDBStateStoreConfigSetter;
+import org.hypertrace.core.kafkastreams.framework.rocksdb.BoundedMemoryConfigSetter;
 import org.hypertrace.core.kafkastreams.framework.timestampextractors.UseWallclockTimeOnInvalidTimestamp;
 import org.hypertrace.core.kafkastreams.framework.topics.creator.KafkaTopicCreator;
 import org.hypertrace.core.kafkastreams.framework.util.ExceptionUtils;
@@ -158,7 +158,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
         .put(DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, UseWallclockTimeOnInvalidTimestamp.class);
     baseStreamsConfig.put(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
         LogAndContinueExceptionHandler.class);
-    baseStreamsConfig.put(ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, RocksDBStateStoreConfigSetter.class);
+    baseStreamsConfig.put(ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, BoundedMemoryConfigSetter.class);
 
     // ##########################
     // Default SerDe configurations
@@ -201,9 +201,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
       Map<String, KStream<?, ?>> sourceStreams);
 
   public Map<String, Object> getStreamsConfig(Config jobConfig) {
-    Map<String, Object> streamsConfig = new HashMap<>(
+    return new HashMap<>(
         ConfigUtils.getFlatMapConfig(jobConfig, getStreamsConfigKey()));
-    return streamsConfig;
   }
 
   public String getStreamsConfigKey() {

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
@@ -17,8 +17,8 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.hypertrace.core.kafkastreams.framework.rocksdb.BoundedMemoryConfigSetter;
-import org.hypertrace.core.kafkastreams.framework.timestampextractors.UseWallclockTimeOnInvalidTimestamp;
 import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,7 +78,7 @@ public class SampleAppTest {
     assertThat(baseStreamsConfig.get(DEFAULT_VALUE_SERDE_CLASS_CONFIG), is(
         SpecificAvroSerde.class));
     assertThat(baseStreamsConfig.get(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG),
-        is(UseWallclockTimeOnInvalidTimestamp.class));
-    assertThat(producerPrefix(ACKS_CONFIG), is("all"));
+        is(LogAndContinueExceptionHandler.class));
+    assertThat(baseStreamsConfig.get(producerPrefix(ACKS_CONFIG)), is("all"));
   }
 }

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
@@ -1,22 +1,31 @@
 package org.hypertrace.core.kafkastreams.framework;
 
+import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
+import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.hypertrace.core.serviceframework.config.ConfigClient;
+import org.hypertrace.core.kafkastreams.framework.rocksdb.BoundedMemoryConfigSetter;
+import org.hypertrace.core.kafkastreams.framework.timestampextractors.UseWallclockTimeOnInvalidTimestamp;
+import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
+@SetEnvironmentVariable(key = "SERVICE_NAME", value = "sample-kafka-streams-service")
 public class SampleAppTest {
 
   private TopologyTestDriver td;
@@ -27,16 +36,14 @@ public class SampleAppTest {
   private Properties streamsConfig;
 
   @BeforeEach
-  @SetEnvironmentVariable(key = "SERVICE_NAME", value = "sample-kafka-streams-service")
   public void setup() {
-    Config config = ConfigFactory.parseURL(
-        getClass().getClassLoader()
-            .getResource("configs/sample-kafka-streams-service/application.conf"));
-    sampleApp = new SampleApp(getConfigClientMock(config));
+    sampleApp = new SampleApp(ConfigClientFactory.getClient());
 
     sampleApp.doInit();
     streamsConfig = new Properties();
     streamsConfig.putAll(sampleApp.streamsConfig);
+
+    td = new TopologyTestDriver(sampleApp.topology, streamsConfig);
   }
 
   @AfterEach
@@ -46,8 +53,6 @@ public class SampleAppTest {
 
   @Test
   public void shouldIncludeValueWithLengthGreaterThanFive() {
-    td = new TopologyTestDriver(sampleApp.topology, streamsConfig);
-
     inputTopic = td.createInputTopic(SampleApp.INPUT_TOPIC, Serdes.String().serializer(),
         Serdes.String().serializer());
     outputTopic = td.createOutputTopic(SampleApp.OUTPUT_TOPIC, Serdes.String().deserializer(),
@@ -63,17 +68,17 @@ public class SampleAppTest {
     assertThat(outputTopic.isEmpty(), is(true));
   }
 
-  private ConfigClient getConfigClientMock(Config config) {
-    return new ConfigClient() {
-      @Override
-      public Config getConfig() {
-        return config;
-      }
-
-      @Override
-      public Config getConfig(String s, String s1, String s2, String s3) {
-        return config;
-      }
-    };
+  @Test
+  public void baseStreamsConfigTest() {
+    Map<String, Object> baseStreamsConfig = sampleApp.getBaseStreamsConfig();
+    assertThat(baseStreamsConfig.get(ROCKSDB_CONFIG_SETTER_CLASS_CONFIG), is(
+        BoundedMemoryConfigSetter.class));
+    assertThat(baseStreamsConfig.get(DEFAULT_KEY_SERDE_CLASS_CONFIG), is(
+        SpecificAvroSerde.class));
+    assertThat(baseStreamsConfig.get(DEFAULT_VALUE_SERDE_CLASS_CONFIG), is(
+        SpecificAvroSerde.class));
+    assertThat(baseStreamsConfig.get(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG),
+        is(UseWallclockTimeOnInvalidTimestamp.class));
+    assertThat(producerPrefix(ACKS_CONFIG), is("all"));
   }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->