### PR TITLE
upgrade kafka-streams version to 6.1.0-ccs

### DIFF
--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -12,15 +12,15 @@ tasks.test {
 dependencies {
     api(project(":kafka-streams-serdes"))
     api("com.typesafe:config:1.4.1")
-    api("org.apache.kafka:kafka-streams:6.0.1-ccs")
-    api("io.confluent:kafka-streams-avro-serde:6.0.1")
+    api("org.apache.kafka:kafka-streams:6.1.0-ccs")
+    api("io.confluent:kafka-streams-avro-serde:6.1.0")
 
     implementation("com.google.guava:guava:30.1-jre")
     implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.18")
     implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
-    implementation("org.apache.kafka:kafka-clients:6.0.1-ccs")
+    implementation("org.apache.kafka:kafka-clients:6.1.0-ccs")
 
-    testImplementation("org.apache.kafka:kafka-streams-test-utils:6.0.1-ccs")
+    testImplementation("org.apache.kafka:kafka-streams-test-utils:6.1.0-ccs")
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
     testImplementation("org.junit-pioneer:junit-pioneer:1.1.0")
     testImplementation("org.mockito:mockito-core:3.6.28")

--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -16,8 +16,8 @@ dependencies {
     api("io.confluent:kafka-streams-avro-serde:6.1.0")
 
     implementation("com.google.guava:guava:30.1-jre")
-    implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.18")
-    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
+    implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.21")
+    implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.21")
     implementation("org.apache.kafka:kafka-clients:6.1.0-ccs")
 
     testImplementation("org.apache.kafka:kafka-streams-test-utils:6.1.0-ccs")

--- a/kafka-streams-serdes/build.gradle.kts
+++ b/kafka-streams-serdes/build.gradle.kts
@@ -11,9 +11,9 @@ tasks.test {
 }
 
 dependencies {
-    api("org.apache.kafka:kafka-streams:6.0.1-ccs")
+    api("org.apache.kafka:kafka-streams:6.1.0-ccs")
     implementation("org.apache.avro:avro:1.9.2")
-    implementation("org.apache.kafka:kafka-clients:6.0.1-ccs")
+    implementation("org.apache.kafka:kafka-clients:6.1.0-ccs")
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
     constraints {
         api("com.fasterxml.jackson.core:jackson-databind:2.11.0") {


### PR DESCRIPTION
Version 6.1.0-ccs (Apache Kafka version 2.7) has introduced a new set of metrics for monitoring RocksDB memory consumption: https://issues.apache.org/jira/browse/KAFKA-9924

This will be helpful in monitoring off-heap memory usage in stateful services.