### PR TITLE
Fix RocksDB native memory leak in stateful applications

### DIFF
--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/rocksdb/RocksDBCacheProvider.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/rocksdb/RocksDBCacheProvider.java
@@ -13,6 +13,7 @@ import static org.hypertrace.core.kafkastreams.framework.rocksdb.RocksDBConfigs.
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.streams.state.internals.BlockBasedTableConfigWithAccessibleCache;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Cache;
 import org.rocksdb.LRUCache;
@@ -107,7 +108,7 @@ public class RocksDBCacheProvider {
           cacheTotalCapacity / (1024 * 1024), writeBuffersRatio, highPriorityPoolRatio);
     }
 
-    final BlockBasedTableConfig tableConfig = (BlockBasedTableConfig) options.tableFormatConfig();
+    final BlockBasedTableConfigWithAccessibleCache tableConfig = (BlockBasedTableConfigWithAccessibleCache) options.tableFormatConfig();
 
     // ######### Block cache (Read buffers) #########
     if (configs.containsKey(BLOCK_SIZE)) {
@@ -133,6 +134,7 @@ public class RocksDBCacheProvider {
 
     options.setWriteBufferManager(writeBufferManager);
 
+    tableConfig.blockCache().close();
     tableConfig.setBlockCache(cache);
     options.setTableFormatConfig(tableConfig);
   }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/rocksdb/RocksDBCacheProvider.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/rocksdb/RocksDBCacheProvider.java
@@ -134,8 +134,12 @@ public class RocksDBCacheProvider {
 
     options.setWriteBufferManager(writeBufferManager);
 
-    tableConfig.blockCache().close();
-    tableConfig.setBlockCache(cache);
+    final Cache oldCache = tableConfig.blockCache();
+    if(oldCache != null) {
+      LOG.info("Releasing old rocksdb cache before setting shared cache.");
+      oldCache.close();
+    }
+    tableConfig.setBlockCache(this.cache);
     options.setTableFormatConfig(tableConfig);
   }
 

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/rocksdb/BoundedMemoryConfigSetterTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/rocksdb/BoundedMemoryConfigSetterTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
+import org.apache.kafka.streams.state.internals.BlockBasedTableConfigWithAccessibleCache;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.CompressionType;
 import org.rocksdb.InfoLogLevel;
+import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
 
 class BoundedMemoryConfigSetterTest {
@@ -41,7 +43,9 @@ class BoundedMemoryConfigSetterTest {
     RocksDBCacheProvider.get().testDestroy();
     options = new Options();
     configs = new HashMap<>();
-    tableConfig = new BlockBasedTableConfig();
+    tableConfig = new BlockBasedTableConfigWithAccessibleCache();
+    // mimic kafka streams
+    tableConfig.setBlockCache(new LRUCache(32 * 1024));
     options.setTableFormatConfig(tableConfig);
     configSetter = new BoundedMemoryConfigSetter();
   }


### PR DESCRIPTION
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->