### PR TITLE
Add a new partitioner that can try stopping producing events configured partitions

### DIFF
--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/FilteredUniformStickyPartitionCache.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/FilteredUniformStickyPartitionCache.java
@@ -1,0 +1,48 @@
+package org.hypertrace.core.kafkastreams.framework.partitioner;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Maps;
+import org.apache.kafka.clients.producer.internals.StickyPartitionCache;
+import org.apache.kafka.common.Cluster;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * An internal class that implements a cache used for filtered sticky partitioning behavior. The cache tracks the current sticky
+ * partition for any given topic.
+ */
+public class FilteredUniformStickyPartitionCache extends StickyPartitionCache  {
+    private final String configRegex = "filtered\\.partitioner\\.(.*?)\\.excluded\\.partitions";
+    private final Pattern pattern = Pattern.compile(configRegex);
+    private final Map<String, Set<Integer>> excludedTopicPartitions = Maps.newConcurrentMap();
+
+    public void configure(Map<String, ?> configs) {
+        configs.entrySet().stream().filter(config -> pattern.matcher(config.getKey()).find()).forEach(config -> {
+            Matcher matcher = pattern.matcher(config.getKey());
+            matcher.find();
+            String topic = matcher.group(1);
+            String excludePartitionsStr = (String) config.getValue();
+            Set<Integer> excludedPartitions = Splitter.on(",")
+                    .trimResults()
+                    .splitToStream(excludePartitionsStr)
+                    .map(Integer::valueOf)
+                    .collect(Collectors.toSet());
+            excludedTopicPartitions.put(topic, excludedPartitions);
+        });
+    }
+
+    public int nextPartition(String topic, Cluster cluster, int prevPartition) {
+        int newPartition = super.nextPartition(topic, cluster, prevPartition);
+        if(excludedTopicPartitions.containsKey(topic)) {
+         Set<Integer> partitionsExcluded =  excludedTopicPartitions.get(topic);
+         while(partitionsExcluded.contains(newPartition)) {
+             newPartition = super.nextPartition(topic, cluster, newPartition);
+         }
+        }
+        return newPartition;
+    }
+}

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/FilteredUniformStickyPartitioner.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/FilteredUniformStickyPartitioner.java
@@ -1,0 +1,45 @@
+package org.hypertrace.core.kafkastreams.framework.partitioner;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+
+import java.util.Map;
+
+/**
+ * The partitioning strategy:
+ * <ul>
+ * <li>If a partition is specified in the record, use it
+ * <li>Otherwise choose the sticky non-excluded partition that changes when the batch is full.
+ *
+ *
+ * NOTE: In contrast to the DefaultPartitioner, the record key is NOT used as part of the partitioning strategy in this
+ *       partitioner. Records with the same key are not guaranteed to be sent to the same partition.
+ *
+ * NOTE: Exclusion of partitions is done best-effort basis. There are some scenarios, where this
+ *       partitioner. Records with the same key are not guaranteed to be sent to the same partition.
+ * See KIP-480 for details about sticky partitioning.
+ */
+public class FilteredUniformStickyPartitioner implements Partitioner {
+
+  private final FilteredUniformStickyPartitionCache stickyPartitionCache =
+      new FilteredUniformStickyPartitionCache();
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    stickyPartitionCache.configure(configs);
+  }
+
+  @Override
+  public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+    return stickyPartitionCache.partition(topic, cluster);
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
+    stickyPartitionCache.nextPartition(topic, cluster, prevPartition);
+  }
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/partitioner/FilteredUniformStickyPartitionerTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/partitioner/FilteredUniformStickyPartitionerTest.java
@@ -1,0 +1,300 @@
+package org.hypertrace.core.kafkastreams.framework.partitioner;
+
+import com.google.common.collect.Maps;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FilteredUniformStickyPartitionerTest {
+  private static final Node[] NODES =
+      new Node[] {
+        new Node(0, "localhost", 99), new Node(1, "localhost", 100), new Node(2, "localhost", 101)
+      };
+
+  private static final String TOPIC_A = "TOPIC_A";
+  private static final String TOPIC_B = "TOPIC_B";
+
+  @Test
+  public void testRoundRobinWithUnavailablePartitions() {
+    // Intentionally make the partition list not in partition order to test the edge
+    // cases.
+    List<PartitionInfo> partitions =
+        asList(
+            new PartitionInfo("test", 1, null, NODES, NODES),
+            new PartitionInfo("test", 2, NODES[1], NODES, NODES),
+            new PartitionInfo("test", 0, NODES[0], NODES, NODES));
+    // When there are some unavailable partitions, we want to make sure that (1) we
+    // always pick an available partition,
+    // and (2) the available partitions are selected in a sticky way.
+    int countForPart0 = 0;
+    int countForPart2 = 0;
+    int part = 0;
+    Partitioner partitioner = new FilteredUniformStickyPartitioner();
+    Cluster cluster =
+        new Cluster(
+            "clusterId",
+            asList(NODES[0], NODES[1], NODES[2]),
+            partitions,
+            Collections.<String>emptySet(),
+            Collections.<String>emptySet());
+    for (int i = 0; i < 50; i++) {
+      part = partitioner.partition("test", null, null, null, null, cluster);
+      assertTrue(
+          part == 0 || part == 2, "We should never choose a leader-less node in round robin");
+      if (part == 0) countForPart0++;
+      else countForPart2++;
+    }
+    // Simulates switching the sticky partition on a new batch.
+    partitioner.onNewBatch("test", cluster, part);
+    for (int i = 1; i <= 50; i++) {
+      part = partitioner.partition("test", null, null, null, null, cluster);
+      assertTrue(
+          part == 0 || part == 2, "We should never choose a leader-less node in round robin");
+      if (part == 0) countForPart0++;
+      else countForPart2++;
+    }
+    assertEquals(
+        countForPart0,
+        countForPart2,
+        "The distribution between two available partitions should be even");
+  }
+
+  @Test
+  public void testRoundRobinWithKeyBytes() throws InterruptedException {
+    List<PartitionInfo> allPartitions =
+        asList(
+            new PartitionInfo(TOPIC_A, 0, NODES[0], NODES, NODES),
+            new PartitionInfo(TOPIC_A, 1, NODES[1], NODES, NODES),
+            new PartitionInfo(TOPIC_A, 2, NODES[1], NODES, NODES),
+            new PartitionInfo(TOPIC_B, 0, NODES[0], NODES, NODES));
+    Cluster testCluster =
+        new Cluster(
+            "clusterId",
+            asList(NODES[0], NODES[1], NODES[2]),
+            allPartitions,
+            Collections.<String>emptySet(),
+            Collections.<String>emptySet());
+
+    final Map<Integer, Integer> partitionCount = new HashMap<>();
+
+    final byte[] keyBytes = "key".getBytes();
+    int partition = 0;
+    Partitioner partitioner = new FilteredUniformStickyPartitioner();
+    for (int i = 0; i < 30; ++i) {
+      partition = partitioner.partition(TOPIC_A, null, keyBytes, null, null, testCluster);
+      Integer count = partitionCount.get(partition);
+      if (null == count) count = 0;
+      partitionCount.put(partition, count + 1);
+
+      if (i % 5 == 0) {
+        partitioner.partition(TOPIC_B, null, keyBytes, null, null, testCluster);
+      }
+    }
+    // Simulate a batch filling up and switching the sticky partition.
+    partitioner.onNewBatch(TOPIC_A, testCluster, partition);
+    partitioner.onNewBatch(TOPIC_B, testCluster, 0);
+
+    // Save old partition to ensure that the wrong partition does not trigger a new batch.
+    int oldPart = partition;
+
+    for (int i = 0; i < 30; ++i) {
+      partition = partitioner.partition(TOPIC_A, null, keyBytes, null, null, testCluster);
+      Integer count = partitionCount.get(partition);
+      if (null == count) count = 0;
+      partitionCount.put(partition, count + 1);
+
+      if (i % 5 == 0) {
+        partitioner.partition(TOPIC_B, null, keyBytes, null, null, testCluster);
+      }
+    }
+
+    int newPart = partition;
+
+    // Attempt to switch the partition with the wrong previous partition. Sticky partition should
+    // not change.
+    partitioner.onNewBatch(TOPIC_A, testCluster, oldPart);
+
+    for (int i = 0; i < 30; ++i) {
+      partition = partitioner.partition(TOPIC_A, null, keyBytes, null, null, testCluster);
+      Integer count = partitionCount.get(partition);
+      if (null == count) count = 0;
+      partitionCount.put(partition, count + 1);
+
+      if (i % 5 == 0) {
+        partitioner.partition(TOPIC_B, null, keyBytes, null, null, testCluster);
+      }
+    }
+
+    assertEquals(30, partitionCount.get(oldPart).intValue());
+    assertEquals(60, partitionCount.get(newPart).intValue());
+  }
+
+  @Test
+  public void testRoundRobinWithNullKeyBytes() {
+    List<PartitionInfo> allPartitions =
+        asList(
+            new PartitionInfo(TOPIC_A, 0, NODES[0], NODES, NODES),
+            new PartitionInfo(TOPIC_A, 1, NODES[1], NODES, NODES),
+            new PartitionInfo(TOPIC_A, 2, NODES[1], NODES, NODES),
+            new PartitionInfo(TOPIC_B, 0, NODES[0], NODES, NODES));
+    Cluster testCluster =
+        new Cluster(
+            "clusterId",
+            asList(NODES[0], NODES[1], NODES[2]),
+            allPartitions,
+            Collections.<String>emptySet(),
+            Collections.<String>emptySet());
+
+    final Map<Integer, Integer> partitionCount = new HashMap<>();
+
+    int partition = 0;
+    Partitioner partitioner = new FilteredUniformStickyPartitioner();
+    for (int i = 0; i < 30; ++i) {
+      partition = partitioner.partition(TOPIC_A, null, null, null, null, testCluster);
+      Integer count = partitionCount.get(partition);
+      if (null == count) count = 0;
+      partitionCount.put(partition, count + 1);
+
+      if (i % 5 == 0) {
+        partitioner.partition(TOPIC_B, null, null, null, null, testCluster);
+      }
+    }
+    // Simulate a batch filling up and switching the sticky partition.
+    partitioner.onNewBatch(TOPIC_A, testCluster, partition);
+    partitioner.onNewBatch(TOPIC_B, testCluster, 0);
+
+    // Save old partition to ensure that the wrong partition does not trigger a new batch.
+    int oldPart = partition;
+
+    for (int i = 0; i < 30; ++i) {
+      partition = partitioner.partition(TOPIC_A, null, null, null, null, testCluster);
+      Integer count = partitionCount.get(partition);
+      if (null == count) count = 0;
+      partitionCount.put(partition, count + 1);
+
+      if (i % 5 == 0) {
+        partitioner.partition(TOPIC_B, null, null, null, null, testCluster);
+      }
+    }
+
+    int newPart = partition;
+
+    // Attempt to switch the partition with the wrong previous partition. Sticky partition should
+    // not change.
+    partitioner.onNewBatch(TOPIC_A, testCluster, oldPart);
+
+    for (int i = 0; i < 30; ++i) {
+      partition = partitioner.partition(TOPIC_A, null, null, null, null, testCluster);
+      Integer count = partitionCount.get(partition);
+      if (null == count) count = 0;
+      partitionCount.put(partition, count + 1);
+
+      if (i % 5 == 0) {
+        partitioner.partition(TOPIC_B, null, null, null, null, testCluster);
+      }
+    }
+
+    assertEquals(30, partitionCount.get(oldPart).intValue());
+    assertEquals(60, partitionCount.get(newPart).intValue());
+  }
+
+  @Test
+  public void testRoundRobinWithNullKeyBytesAndPartitionExclusionFilter() {
+    List<PartitionInfo> allPartitions =
+        asList(
+            new PartitionInfo(TOPIC_A, 0, NODES[0], NODES, NODES),
+            new PartitionInfo(TOPIC_A, 1, NODES[1], NODES, NODES),
+            new PartitionInfo(TOPIC_A, 2, NODES[0], NODES, NODES),
+            new PartitionInfo(TOPIC_A, 3, NODES[1], NODES, NODES),
+            new PartitionInfo(TOPIC_B, 0, NODES[0], NODES, NODES),
+            new PartitionInfo(TOPIC_B, 1, NODES[1], NODES, NODES),
+            new PartitionInfo(TOPIC_B, 2, NODES[1], NODES, NODES));
+    Cluster testCluster =
+        new Cluster(
+            "clusterId",
+            asList(NODES[0], NODES[1], NODES[2]),
+            allPartitions,
+            Collections.<String>emptySet(),
+            Collections.<String>emptySet());
+
+    final Map<Integer, Integer> topicAMsgsPerPartitionCounter = new HashMap<>();
+    final Map<Integer, Integer> topicBMsgsPerPartitionCounter = new HashMap<>();
+
+    Partitioner partitioner = new FilteredUniformStickyPartitioner();
+    Map<String, String> kafkaProducerConfigs = Maps.newHashMap();
+    kafkaProducerConfigs.put(
+        String.format("filtered.partitioner.%s.excluded.partitions", TOPIC_A), "2,3");
+    kafkaProducerConfigs.put(
+        String.format("filtered.partitioner.%s.excluded.partitions", TOPIC_B), "0,2");
+
+    int topicAPartition = 0;
+    int topicBPartition = 0;
+
+    partitioner.configure(kafkaProducerConfigs);
+    for (int i = 0; i < 30; ++i) {
+      topicAPartition = partitioner.partition(TOPIC_A, null, null, null, null, testCluster);
+      Integer topicACount = topicAMsgsPerPartitionCounter.get(topicAPartition);
+      if (null == topicACount) topicACount = 0;
+      topicAMsgsPerPartitionCounter.put(topicAPartition, topicACount + 1);
+
+      topicBPartition = partitioner.partition(TOPIC_B, null, null, null, null, testCluster);
+      Integer topicBCount = topicBMsgsPerPartitionCounter.get(topicBPartition);
+      if (null == topicBCount) topicBCount = 0;
+      topicBMsgsPerPartitionCounter.put(topicBPartition, topicBCount + 1);
+    }
+
+    // Simulate a batch filling up and switching the sticky partition.
+    partitioner.onNewBatch(TOPIC_A, testCluster, topicAPartition);
+    partitioner.onNewBatch(TOPIC_B, testCluster, topicBPartition);
+
+    // Save old partition to ensure that the wrong partition does not trigger a new batch.
+    int oldTopicAPart = topicAPartition;
+    int oldTopicBPart = topicBPartition;
+
+    assertEquals(30, topicAMsgsPerPartitionCounter.get(oldTopicAPart).intValue());
+    assertEquals(30, topicBMsgsPerPartitionCounter.get(1).intValue());
+
+    for (int i = 0; i < 30; ++i) {
+      topicAPartition = partitioner.partition(TOPIC_A, null, null, null, null, testCluster);
+      Integer topicACount = topicAMsgsPerPartitionCounter.get(topicAPartition);
+      if (null == topicACount) topicACount = 0;
+      topicAMsgsPerPartitionCounter.put(topicAPartition, topicACount + 1);
+
+      topicBPartition = partitioner.partition(TOPIC_B, null, null, null, null, testCluster);
+      Integer topicBCount = topicBMsgsPerPartitionCounter.get(topicBPartition);
+      if (null == topicBCount) topicBCount = 0;
+      topicBMsgsPerPartitionCounter.put(topicBPartition, topicBCount + 1);
+    }
+
+    // Attempt to switch the partition with the wrong previous partition. Sticky partition should
+    // not change.
+    partitioner.onNewBatch(TOPIC_A, testCluster, oldTopicAPart);
+    partitioner.onNewBatch(TOPIC_B, testCluster, oldTopicBPart);
+
+    for (int i = 0; i < 30; ++i) {
+      topicAPartition = partitioner.partition(TOPIC_A, null, null, null, null, testCluster);
+      Integer topicACount = topicAMsgsPerPartitionCounter.get(topicAPartition);
+      if (null == topicACount) topicACount = 0;
+      topicAMsgsPerPartitionCounter.put(topicAPartition, topicACount + 1);
+
+      topicBPartition = partitioner.partition(TOPIC_B, null, null, null, null, testCluster);
+      Integer topicBCount = topicBMsgsPerPartitionCounter.get(topicBPartition);
+      if (null == topicBCount) topicBCount = 0;
+      topicBMsgsPerPartitionCounter.put(topicBPartition, topicBCount + 1);
+    }
+
+    assertEquals(90, topicAMsgsPerPartitionCounter.values().stream().reduce((a, b) -> a + b).get());
+    assertEquals(90, topicBMsgsPerPartitionCounter.get(1).intValue());
+  }
+}

--- a/kafka-streams-serdes/build.gradle.kts
+++ b/kafka-streams-serdes/build.gradle.kts
@@ -16,9 +16,9 @@ dependencies {
   implementation("org.apache.kafka:kafka-clients:6.0.1-ccs")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   constraints {
-    api("com.fasterxml.jackson.core:jackson-databind:2.11.0") {
-      because("XML External Entity (XXE) Injection (new) [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1048302] in com.fasterxml.jackson.core:jackson-databind@2.10.5\n" +
-          "   introduced by com.fasterxml.jackson.core:jackson-databind@2.10.5")
+    api("com.fasterxml.jackson.core:jackson-databind:2.12.6") {
+      because("Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.12.2\n" +
+              "    introduced by org.apache.avro:avro@1.10.2 > com.fasterxml.jackson.core:jackson-databind@2.12.2 and 2 other path(s)")
     }
     implementation("org.apache.commons:commons-compress:1.21") {
       because("Multiple Vulnerabilities [https://nvd.nist.gov/vuln/detail/CVE-2021-35515] [https://nvd.nist.gov/vuln/detail/CVE-2021-35516] [https://nvd.nist.gov/vuln/detail/CVE-2021-35517] [https://nvd.nist.gov/vuln/detail/CVE-2021-36090] in org.apache.commons:commons-compress@1.20")


### PR DESCRIPTION
## Description
Add a new kafka partitioner with the ability to skip few configured partitions while producing events.

### Testing
Added unit testing covering all the scenarios

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
