### PR TITLE
feat: Add ConsolidatedKafkaStreamsApp base class 

### DIFF
--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
   implementation("org.apache.kafka:kafka-clients:6.0.1-ccs")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.31")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.31")
+  implementation("org.apache.commons:commons-lang3:3.12.0")
+
 
   constraints {
     api("org.glassfish.jersey.core:jersey-common:2.34") {

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/ConsolidatedKafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/ConsolidatedKafkaStreamsApp.java
@@ -1,0 +1,139 @@
+package org.hypertrace.core.kafkastreams.framework;
+
+import com.typesafe.config.Config;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
+import org.hypertrace.core.serviceframework.config.ConfigUtils;
+
+/**
+ * Base class for consolidating multiple independent KafkaStreamApps
+ */
+public abstract class ConsolidatedKafkaStreamsApp extends KafkaStreamsApp {
+
+  static final String SUB_TOPOLOGY_NAMES_CONFIG_KEY = "sub.topology.names";
+  static final String ENV_CLUSTER_NAME_KEY = "cluster.name";
+  static final String ENV_POD_NAME_KEY = "pod.name";
+  static final String ENV_CONTAINER_NAME_KEY = "container.name";
+
+  private Map<String, Pair<String, KafkaStreamsApp>> jobNameToSubTopology = new HashMap<>();
+
+  public ConsolidatedKafkaStreamsApp(
+      ConfigClient configClient) {
+    super(configClient);
+  }
+
+  @Override
+  public StreamsBuilder buildTopology(
+      Map<String, Object> properties,
+      StreamsBuilder streamsBuilder,
+      Map<String, KStream<?, ?>> inputStreams) {
+
+    List<String> subTopologiesNames = getSubTopologiesNames(properties);
+    for (String subTopologyName : subTopologiesNames) {
+      getLogger().info("Building sub topology: {}", subTopologyName);
+      streamsBuilder = buildSubTopology(subTopologyName, properties, streamsBuilder, inputStreams);
+    }
+
+    return streamsBuilder;
+  }
+
+  public void doStop() {
+    jobNameToSubTopology.values()
+        .forEach(pair -> pair.getRight().doCleanUpForConsolidatedDeployment());
+    super.doStop();
+  }
+
+  @Override
+  public List<String> getInputTopics(Map<String, Object> properties) {
+    Set<String> inputTopics = new HashSet<>();
+    for (Map.Entry<String, Pair<String, KafkaStreamsApp>> entry : jobNameToSubTopology.entrySet()) {
+      List<String> subTopologyInputTopics = entry.getValue().getRight().getInputTopics(properties);
+      inputTopics.addAll(subTopologyInputTopics);
+    }
+    return new ArrayList<>(inputTopics);
+  }
+
+  @Override
+  public List<String> getOutputTopics(Map<String, Object> properties) {
+    Set<String> outputTopics = new HashSet<>();
+    for (Map.Entry<String, Pair<String, KafkaStreamsApp>> entry : jobNameToSubTopology.entrySet()) {
+      List<String> subTopologyOutputTopics = entry.getValue().getRight()
+          .getOutputTopics(properties);
+      outputTopics.addAll(subTopologyOutputTopics);
+    }
+    return new ArrayList<>(outputTopics);
+  }
+
+  protected abstract KafkaStreamsApp getSubTopologyInstance(String name);
+
+  private StreamsBuilder buildSubTopology(
+      String subTopologyName,
+      Map<String, Object> properties,
+      StreamsBuilder streamsBuilder,
+      Map<String, KStream<?, ?>> inputStreams) {
+    // create an instance and retains is reference to be used later in other methods
+    KafkaStreamsApp subTopology = getSubTopologyInstance(subTopologyName);
+    jobNameToSubTopology.put(subTopologyName, Pair.of(subTopology.getJobConfigKey(), subTopology));
+
+    // need to use its own copy as input/output topics are different
+    Config subTopologyJobConfig = getSubJobConfig(subTopologyName);
+
+    Config jobConfig = getJobConfig(properties);
+    if (jobConfig.hasPath(subTopology.getJobConfigKey())) {
+      Config subTopologyJobOverrideConfig = jobConfig.getConfig(subTopology.getJobConfigKey());
+      subTopologyJobConfig =
+          subTopologyJobOverrideConfig.withFallback(subTopologyJobConfig).resolve();
+    }
+
+    Map<String, Object> flattenSubTopologyConfig =
+        subTopology.getStreamsConfig(subTopologyJobConfig);
+    flattenSubTopologyConfig.put(subTopology.getJobConfigKey(), subTopologyJobConfig);
+
+    // add specific job properties
+    addProperties(properties, flattenSubTopologyConfig);
+
+    // initialize any dependencies
+    subTopology.doInitForConsolidatedDeployment(subTopologyJobConfig);
+
+    // build the sub-topology
+    streamsBuilder = subTopology.buildTopology(properties, streamsBuilder, inputStreams);
+
+    // retain per job key and its topology
+    jobNameToSubTopology.put(subTopologyName, Pair.of(subTopology.getJobConfigKey(), subTopology));
+    return streamsBuilder;
+  }
+
+  private List<String> getSubTopologiesNames(Map<String, Object> properties) {
+    return getJobConfig(properties).getStringList(SUB_TOPOLOGY_NAMES_CONFIG_KEY);
+  }
+
+  private Config getSubJobConfig(String jobName) {
+    return configClient.getConfig(
+        jobName,
+        ConfigUtils.getEnvironmentProperty(ENV_CLUSTER_NAME_KEY),
+        ConfigUtils.getEnvironmentProperty(ENV_POD_NAME_KEY),
+        ConfigUtils.getEnvironmentProperty(ENV_CONTAINER_NAME_KEY));
+  }
+
+  private Config getJobConfig(Map<String, Object> properties) {
+    return (Config) properties.get(this.getJobConfigKey());
+  }
+
+  private void addProperties(Map<String, Object> baseProps, Map<String, Object> props) {
+    props.forEach(
+        (k, v) -> {
+          if (!baseProps.containsKey(k)) {
+            baseProps.put(k, v);
+          }
+        });
+  }
+
+}

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -145,12 +145,12 @@ public abstract class KafkaStreamsApp extends PlatformService {
    * Any dependencies that need to be initialized need to be done here
    * @param subTopologyJobConfig
    */
-  protected void doInitForConsolidatedDeployment(Config subTopologyJobConfig){}
+  protected void doInitForConsolidatedKStreamApp(Config subTopologyJobConfig){}
 
   /**
    * Cleanup any dependencies before the {@link ConsolidatedKafkaStreamsApp#doStop()} is invoked
    */
-  protected void doCleanUpForConsolidatedDeployment(){}
+  protected void doCleanUpForConsolidatedKStreamApp(){}
 
   @Override
   public boolean healthCheck() {

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -140,6 +140,18 @@ public abstract class KafkaStreamsApp extends PlatformService {
     app.close(Duration.ofSeconds(30));
   }
 
+  /**
+   * This method is invoked just before a subtopology is created
+   * Any dependencies that need to be initialized need to be done here
+   * @param subTopologyJobConfig
+   */
+  protected void doInitForConsolidatedDeployment(Config subTopologyJobConfig){}
+
+  /**
+   * Cleanup any dependencies before the {@link ConsolidatedKafkaStreamsApp#doStop()} is invoked
+   */
+  protected void doCleanUpForConsolidatedDeployment(){}
+
   @Override
   public boolean healthCheck() {
     return app.state().isRunningOrRebalancing();

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/ConsolidatedService.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/ConsolidatedService.java
@@ -1,0 +1,26 @@
+package org.hypertrace.core.kafkastreams.framework;
+
+import org.hypertrace.core.serviceframework.config.ConfigClient;
+import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
+
+public class ConsolidatedService extends ConsolidatedKafkaStreamsApp{
+
+  public ConsolidatedService(
+      ConfigClient configClient) {
+    super(configClient);
+  }
+
+  @Override
+  protected KafkaStreamsApp getSubTopologyInstance(String name) {
+    switch (name){
+      case "sample-kafka-streams-service1":{
+        return new Service1(ConfigClientFactory.getClient());
+      }
+      case "sample-kafka-streams-service2":{
+        return new Service2(ConfigClientFactory.getClient());
+      }
+      default:
+        throw new RuntimeException("Unknown sub topology");
+    }
+  }
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/ConsolidatedServiceTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/ConsolidatedServiceTest.java
@@ -1,0 +1,75 @@
+package org.hypertrace.core.kafkastreams.framework;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Properties;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+@SetEnvironmentVariable(key = "SERVICE_NAME", value = "sample-consolidated-kafka-streams-service")
+public class ConsolidatedServiceTest {
+  private TopologyTestDriver td;
+  private TestInputTopic<String, String> inputTopic1;
+  private TestOutputTopic<String, String> outputTopic1;
+
+  private ConsolidatedService underTest;
+  private Properties streamsConfig;
+
+  private TestInputTopic<String, String> inputTopic2;
+  private TestOutputTopic<String, String> outputTopic2;
+
+
+  @BeforeEach
+  public void setup() {
+    underTest = new ConsolidatedService(ConfigClientFactory.getClient());
+
+    underTest.doInit();
+    streamsConfig = new Properties();
+    streamsConfig.putAll(underTest.streamsConfig);
+
+    td = new TopologyTestDriver(underTest.topology, streamsConfig);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    td.close();
+  }
+
+  @Test
+  public void checkDataFlowsThroughBothSubTopologies() {
+    inputTopic1 = td.createInputTopic(Service1.INPUT_TOPIC, Serdes.String().serializer(),
+        Serdes.String().serializer());
+    outputTopic1 = td.createOutputTopic(Service1.OUTPUT_TOPIC, Serdes.String().deserializer(),
+        Serdes.String().deserializer());
+
+    inputTopic2 = td.createInputTopic(Service2.INPUT_TOPIC, Serdes.String().serializer(),
+        Serdes.String().serializer());
+    outputTopic2 = td.createOutputTopic(Service2.OUTPUT_TOPIC, Serdes.String().deserializer(),
+        Serdes.String().deserializer());
+
+    assertThat(outputTopic1.isEmpty(), is(true));
+    assertThat(outputTopic2.isEmpty(), is(true));
+
+    inputTopic1.pipeInput("foo", "barrrrr");
+    inputTopic2.pipeInput("foo", "barrrrr");
+    assertThat(outputTopic1.readValue(), equalTo("barrrrr"));
+    assertThat(outputTopic1.isEmpty(), is(true));
+    assertThat(outputTopic2.readValue(), equalTo("barrrrr"));
+    assertThat(outputTopic2.isEmpty(), is(true));
+
+    inputTopic1.pipeInput("foo", "bar");
+    inputTopic2.pipeInput("foo", "bar");
+    assertThat(outputTopic1.isEmpty(), is(true));
+    assertThat(outputTopic2.isEmpty(), is(true));
+  }
+
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.kafkastreams.framework;
 
 
+import com.typesafe.config.Config;
 import java.util.Map;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
@@ -13,6 +14,14 @@ public class SampleApp extends KafkaStreamsApp {
 
   public SampleApp(ConfigClient configClient) {
     super(configClient);
+  }
+
+  @Override
+  protected void doInitForConsolidatedDeployment(Config subTopologyJobConfig) {
+  }
+
+  @Override
+  protected void doCleanUpForConsolidatedDeployment() {
   }
 
   @Override

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleApp.java
@@ -17,11 +17,11 @@ public class SampleApp extends KafkaStreamsApp {
   }
 
   @Override
-  protected void doInitForConsolidatedDeployment(Config subTopologyJobConfig) {
+  protected void doInitForConsolidatedKStreamApp(Config subTopologyJobConfig) {
   }
 
   @Override
-  protected void doCleanUpForConsolidatedDeployment() {
+  protected void doCleanUpForConsolidatedKStreamApp() {
   }
 
   @Override

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/Service1.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/Service1.java
@@ -1,0 +1,28 @@
+package org.hypertrace.core.kafkastreams.framework;
+
+import java.util.Map;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
+
+public class Service1 extends KafkaStreamsApp {
+
+  static String INPUT_TOPIC = "service1_input";
+  static String OUTPUT_TOPIC = "service1_output";
+
+  public Service1(ConfigClient configClient) {
+    super(configClient);
+  }
+
+  @Override
+  public StreamsBuilder buildTopology(Map<String, Object> streamsConfig,
+      StreamsBuilder streamsBuilder, Map<String, KStream<?, ?>> sourceStreams) {
+    KStream<String, String> stream = streamsBuilder.stream(INPUT_TOPIC);
+    stream.filter((k, v) -> v.length() > 5).to(OUTPUT_TOPIC);
+    return streamsBuilder;
+  }
+
+  public String getServiceName(){
+    return "service1";
+  }
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/Service2.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/Service2.java
@@ -1,0 +1,29 @@
+package org.hypertrace.core.kafkastreams.framework;
+
+import java.util.Map;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.hypertrace.core.serviceframework.config.ConfigClient;
+
+public class Service2 extends KafkaStreamsApp{
+
+  static String INPUT_TOPIC = "service2_input";
+  static String OUTPUT_TOPIC = "service2_output";
+
+
+  public Service2(ConfigClient configClient) {
+    super(configClient);
+  }
+
+  @Override
+  public StreamsBuilder buildTopology(Map<String, Object> streamsConfig,
+      StreamsBuilder streamsBuilder, Map<String, KStream<?, ?>> sourceStreams) {
+    KStream<String, String> stream = streamsBuilder.stream(INPUT_TOPIC);
+    stream.filter((k, v) -> v.length() > 5).to(OUTPUT_TOPIC);
+    return streamsBuilder;
+  }
+
+  public String getServiceName(){
+    return "service2";
+  }
+}

--- a/kafka-streams-framework/src/test/resources/configs/sample-consolidated-kafka-streams-service/application.conf
+++ b/kafka-streams-framework/src/test/resources/configs/sample-consolidated-kafka-streams-service/application.conf
@@ -1,0 +1,20 @@
+service.name = sample-consolidated-kafka-streams-service
+
+sub.topology.names = ["sample-kafka-streams-service1", "sample-kafka-streams-service2"]
+
+kafka.streams.config = {
+  application.id = consolidated-service
+  bootstrap.servers = "localhost:9092"
+  default.key.serde="org.apache.kafka.common.serialization.Serdes$StringSerde"
+  default.value.serde="org.apache.kafka.common.serialization.Serdes$StringSerde"
+}
+
+service1-job-config = {
+  key1 = "value11"
+  key2 = "value22"
+}
+
+service2-job-config = {
+  key1 = "value11"
+  key2 = "value22"
+}

--- a/kafka-streams-framework/src/test/resources/configs/sample-kafka-streams-service1/application.conf
+++ b/kafka-streams-framework/src/test/resources/configs/sample-kafka-streams-service1/application.conf
@@ -1,0 +1,11 @@
+service.name = sample-kafka-streams-service1
+
+kafka.streams.config = {
+  application.id = service1
+  bootstrap.servers = "localhost:9092"
+  default.key.serde="org.apache.kafka.common.serialization.Serdes$StringSerde"
+  default.value.serde="org.apache.kafka.common.serialization.Serdes$StringSerde"
+}
+
+key1 = "value1"
+key2 = "value2"

--- a/kafka-streams-framework/src/test/resources/configs/sample-kafka-streams-service2/application.conf
+++ b/kafka-streams-framework/src/test/resources/configs/sample-kafka-streams-service2/application.conf
@@ -1,0 +1,11 @@
+service.name = sample-kafka-streams-service2
+
+kafka.streams.config = {
+  application.id = service2
+  bootstrap.servers = "localhost:9092"
+  default.key.serde="org.apache.kafka.common.serialization.Serdes$StringSerde"
+  default.value.serde="org.apache.kafka.common.serialization.Serdes$StringSerde"
+}
+
+key1 = "value1"
+


### PR DESCRIPTION
## Description
Base class for consolidating and running multiple KafkaStreamsApps as one KafkaStreamsApp 

### Testing
Ran unit tests that tests if 2 KafkaStreamsApps are run as one and messages flow through each topology 

### Checklist:
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

