### PR TITLE
support key hash partitioner

### DIFF
--- a/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/KeyHashPartitioner.java
+++ b/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/KeyHashPartitioner.java
@@ -1,0 +1,18 @@
+package org.hypertrace.core.kafkastreams.framework.partitioner;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+
+public class KeyHashPartitioner<K, V> implements StreamPartitioner<K, V> {
+  private final AtomicInteger currentPartition = new AtomicInteger();
+
+  @Override
+  public Integer partition(String topic, K key, V value, int numPartitions) {
+    int hashcode = 0;
+    if (key != null) {
+      hashcode = key.hashCode();
+    }
+    return Utils.toPositive(hashcode) % numPartitions;
+  }
+}

--- a/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/KeyHashPartitioner.java
+++ b/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/KeyHashPartitioner.java
@@ -1,12 +1,9 @@
 package org.hypertrace.core.kafkastreams.framework.partitioner;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
 public class KeyHashPartitioner<K, V> implements StreamPartitioner<K, V> {
-  private final AtomicInteger currentPartition = new AtomicInteger();
-
   @Override
   public Integer partition(String topic, K key, V value, int numPartitions) {
     int hashcode = 0;


### PR DESCRIPTION
## Description
Support for key hash partitioner to be used as a delegate partitioner.

### Testing
Added unit tests. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
NA.