### PR TITLE
chore: add protobuf constraint

### DIFF
--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -6,12 +6,16 @@ plugins {
 
 var kafkaVersion = "7.2.1"
 var kafkaCcsVersion = "$kafkaVersion-ccs"
+var protobufVersion = "3.21.7"
 
 dependencies {
   constraints {
     api("com.fasterxml.jackson.core:jackson-databind:2.15.2")
     api("org.xerial.snappy:snappy-java:1.1.10.1") {
       because("[https://nvd.nist.gov/vuln/detail/CVE-2023-34455] in 'org.apache.kafka:kafka-clients:*'")
+    }
+    api("com.google.protobuf:protobuf-java-util:3.21.7") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2022-3171")
     }
 
     api("io.confluent:kafka-streams-avro-serde:$kafkaVersion")


### PR DESCRIPTION
## Description

Current kafka protobuf uses a vulnerable version, constraint it in bom.