### PR TITLE
fix: updates grpc utils version for vuln of netty

### DIFF
--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 
-var kafkaVersion = "7.2.1"
+var kafkaVersion = "7.4.0"
 var kafkaCcsVersion = "$kafkaVersion-ccs"
 var protobufVersion = "3.21.7"
 

--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   api(platform(project(":kafka-bom")))
   api("org.apache.kafka:kafka-streams")
   api("io.confluent:kafka-streams-avro-serde")
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.0")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.1")
 
   implementation("org.apache.avro:avro")
   implementation("org.apache.kafka:kafka-clients")

--- a/kafka-streams-partitioners/weighted-group-partitioner/build.gradle.kts
+++ b/kafka-streams-partitioners/weighted-group-partitioner/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
 
   api(platform(project(":kafka-bom")))
   api("org.apache.kafka:kafka-streams")
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.0")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.1")
   api("com.typesafe:config:1.4.2")
   implementation("com.google.guava:guava:32.0.1-jre")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.12.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.12.1")
   implementation("org.hypertrace.config.service:partitioner-config-service-api:0.1.46")
   implementation("org.slf4j:slf4j-api:1.7.36")
 


### PR DESCRIPTION
Ref PR 
- updates grpc: https://github.com/hypertrace/java-grpc-utils/pull/47/files
- updates kafka version to 7.4.0