### PR TITLE
support thread partitioning for async processor

### DIFF
--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/async/Constants.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/async/Constants.java
@@ -4,5 +4,5 @@ public class Constants {
   public static int DEFAULT_ASYNC_EXECUTOR_POOL_SIZE = 16;
   public static int DEFAULT_ASYNC_PROCESSOR_BATCH_SIZE = 5120;
   public static int DEFAULT_ASYNC_PROCESSOR_COMMIT_INTERVAL = 5000;
-  public static String ASYNC_EXECUTOR_POOL_SIZE_KEY = "async.executors.maxPoolSize";
+  public static String ASYNC_EXECUTOR_THREADS_COUNT_KEY = "async.executors.threadsCount";
 }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/async/ExecutorFactory.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/async/ExecutorFactory.java
@@ -1,10 +1,12 @@
 package org.hypertrace.core.kafkastreams.framework.async;
 
-import static org.hypertrace.core.kafkastreams.framework.async.Constants.ASYNC_EXECUTOR_POOL_SIZE_KEY;
+import static org.hypertrace.core.kafkastreams.framework.async.Constants.ASYNC_EXECUTOR_THREADS_COUNT_KEY;
 import static org.hypertrace.core.kafkastreams.framework.async.Constants.DEFAULT_ASYNC_EXECUTOR_POOL_SIZE;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.typesafe.config.Config;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -13,30 +15,45 @@ import java.util.function.Supplier;
 import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 
 public class ExecutorFactory {
-  private static Executor executor;
+  private static List<Executor> executorList;
 
-  public static synchronized Supplier<Executor> getExecutorSupplier(Config config) {
-    if (executor == null) {
-      int poolSize =
-          config.hasPath(ASYNC_EXECUTOR_POOL_SIZE_KEY)
-              ? config.getInt(ASYNC_EXECUTOR_POOL_SIZE_KEY)
+  /** usePool should be set to false if you use KeyToAsyncThreadPartitioner */
+  public static synchronized Supplier<List<Executor>> getExecutorListSupplier(
+      Config config, boolean usePool) {
+    if (executorList == null) {
+      int threadsCount =
+          config.hasPath(ASYNC_EXECUTOR_THREADS_COUNT_KEY)
+              ? config.getInt(ASYNC_EXECUTOR_THREADS_COUNT_KEY)
               : DEFAULT_ASYNC_EXECUTOR_POOL_SIZE;
 
-      if (poolSize > 0) {
+      if (threadsCount == 0) {
+        // direct/sync execution when pool size is explicitly configured to a value <= 0
+        executorList = List.of(Runnable::run);
+      } else if (usePool) {
         ThreadFactory threadFactory =
             new ThreadFactoryBuilder()
                 .setNameFormat("kafka-streams-async-worker-%d")
                 .setDaemon(true)
                 .build();
-        ExecutorService executorSvc = Executors.newFixedThreadPool(poolSize, threadFactory);
+        ExecutorService fixedThreadPool = Executors.newFixedThreadPool(threadsCount, threadFactory);
         PlatformMetricsRegistry.monitorExecutorService(
-            "kafka-streams-async-pool", executorSvc, null);
-        executor = executorSvc;
+            "kafka-streams-async-pool", fixedThreadPool, null);
+        executorList = List.of(fixedThreadPool);
       } else {
-        // direct/sync execution when pool size is explicitly configured to a value <= 0
-        executor = Runnable::run;
+        executorList = new ArrayList<>();
+        for (int i = 0; i < threadsCount; i++) {
+          ThreadFactory threadFactory =
+              new ThreadFactoryBuilder()
+                  .setNameFormat("kafka-streams-async-worker-" + i)
+                  .setDaemon(true)
+                  .build();
+          ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor(threadFactory);
+          PlatformMetricsRegistry.monitorExecutorService(
+              "kafka-streams-async-thread-" + i, singleThreadExecutor, null);
+          executorList.add(singleThreadExecutor);
+        }
       }
     }
-    return () -> executor;
+    return () -> executorList;
   }
 }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/async/KeyToAsyncThreadPartitioner.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/async/KeyToAsyncThreadPartitioner.java
@@ -1,0 +1,5 @@
+package org.hypertrace.core.kafkastreams.framework.async;
+
+public interface KeyToAsyncThreadPartitioner<K> {
+  int getNumericalHashForKey(K key);
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAsyncApp.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAsyncApp.java
@@ -49,7 +49,7 @@ public class SampleAsyncApp extends KafkaStreamsApp {
                 new SlowProcessor(
                     ExecutorFactory.getExecutorListSupplier(kafkaStreamsConfig, false),
                     AsyncProcessorConfig.buildWith(kafkaStreamsConfig, "slow.processor"),
-                    Optional.of(new StringHashCodePartitioner())));
+                    Optional.of(String::hashCode)));
     transform.process(LoggingProcessor::new);
     transform.to(OUTPUT_TOPIC);
     return streamsBuilder;
@@ -98,13 +98,5 @@ class LoggingProcessor implements Processor<String, String, Void, Void> {
   @Override
   public void process(Record<String, String> record) {
     log.info("received - key: {}, value: {}", record.key(), record.value());
-  }
-}
-
-class StringHashCodePartitioner implements KeyToAsyncThreadPartitioner<String> {
-
-  @Override
-  public int getNumericalHashForKey(String key) {
-    return key.hashCode();
   }
 }


### PR DESCRIPTION
## Description
At times we use kafka partitioning as a concurrency control mechanism, in such cases using a thread pool would not help the concurrency problem. To solve for those cases, we need same thread to pick all the messages corresponding to partition key. This PR adds support to do it by storing a list of single threaded executors and submitting tasks to respective threads computing hash of key

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
