### PR TITLE
update default compression type to zstd

### DIFF
--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -228,7 +228,7 @@ public abstract class KafkaStreamsApp extends PlatformService {
     baseStreamsConfig.put(producerPrefix(BATCH_SIZE_CONFIG), "524288");
     // Enable compression on producer for better throughput
     // default - none
-    baseStreamsConfig.put(producerPrefix(COMPRESSION_TYPE_CONFIG), CompressionType.GZIP.name);
+    baseStreamsConfig.put(producerPrefix(COMPRESSION_TYPE_CONFIG), CompressionType.ZSTD.name);
 
     // ##########################
     // Consumer configurations


### PR DESCRIPTION
we observed experimentally `zstd` to be superior in terms of low CPU usage while having similar compression ratio