### PR TITLE
Adding custom proto serdes

### DIFF
--- a/kafka-streams-serdes/build.gradle.kts
+++ b/kafka-streams-serdes/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   `java-library`
   jacoco
+  id("com.google.protobuf") version "0.9.4"
   id("org.hypertrace.avro-plugin")
   id("org.hypertrace.publish-plugin")
   id("org.hypertrace.jacoco-report-plugin")
@@ -15,6 +16,7 @@ dependencies {
 
   api("org.apache.kafka:kafka-clients")
   api("org.apache.avro:avro")
+  implementation("com.google.protobuf:protobuf-java:3.23.0") // Adjust the version as needed
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 }

--- a/kafka-streams-serdes/src/main/java/org/hypertrace/core/kafkastreams/framework/serdes/proto/ProtoDeserializer.java
+++ b/kafka-streams-serdes/src/main/java/org/hypertrace/core/kafkastreams/framework/serdes/proto/ProtoDeserializer.java
@@ -1,0 +1,24 @@
+package org.hypertrace.core.kafkastreams.framework.serdes.proto;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class ProtoDeserializer<T extends Message> implements Deserializer<T> {
+
+  private final Parser<T> parser;
+
+  public ProtoDeserializer(Parser<T> parser) {
+    this.parser = parser;
+  }
+
+  @Override
+  public T deserialize(String s, byte[] bytes) {
+    try {
+      return parser.parseFrom(bytes);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/kafka-streams-serdes/src/main/java/org/hypertrace/core/kafkastreams/framework/serdes/proto/ProtoSerializer.java
+++ b/kafka-streams-serdes/src/main/java/org/hypertrace/core/kafkastreams/framework/serdes/proto/ProtoSerializer.java
@@ -1,0 +1,11 @@
+package org.hypertrace.core.kafkastreams.framework.serdes.proto;
+
+import com.google.protobuf.Message;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class ProtoSerializer<T extends Message> implements Serializer<T> {
+  @Override
+  public byte[] serialize(String topic, T data) {
+    return data.toByteArray();
+  }
+}


### PR DESCRIPTION
## Description
  Adding custom proto serdes to avoid schema validations for proto based events as both producer and consumers are 
  anyways using the same protos to read the message we dont need the schema validation.
 
  

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
