### PR TITLE
fix: issue of last partition not included for certain groups weightage

### DIFF
--- a/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupProfile.java
+++ b/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupProfile.java
@@ -45,7 +45,7 @@ public class WeightedGroupProfile {
         new WeightedGroup(
             "[[default]]",
             weightConsumedSoFar.get(),
-            weightConsumedSoFar.addAndGet(defaultGroupWeight / totalWeight));
+            1.0);
 
     log.info(
         "partitioner default group config - weight range: {}, range end: {}",

--- a/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupProfile.java
+++ b/kafka-streams-partitioners/weighted-group-partitioner/src/main/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupProfile.java
@@ -41,11 +41,7 @@ public class WeightedGroupProfile {
                 groupConfig ->
                     buildEntriesForEachMember(groupConfig, weightConsumedSoFar, totalWeight))
             .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
-    this.defaultGroup =
-        new WeightedGroup(
-            "[[default]]",
-            weightConsumedSoFar.get(),
-            1.0);
+    this.defaultGroup = new WeightedGroup("[[default]]", weightConsumedSoFar.get(), 1.0);
 
     log.info(
         "partitioner default group config - weight range: {}, range end: {}",

--- a/kafka-streams-partitioners/weighted-group-partitioner/src/test/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupPartitionerTest.java
+++ b/kafka-streams-partitioners/weighted-group-partitioner/src/test/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupPartitionerTest.java
@@ -286,7 +286,7 @@ public class WeightedGroupPartitionerTest {
                     .addGroups(newPartitionerGroup("group1", new String[] {"tenant-1"}, 37))
                     .addGroups(
                         newPartitionerGroup("group2", new String[] {"tenant-2", "tenant-3"}, 29))
-                    .addGroups(newPartitionerGroup("group1", new String[] {"tenant-4"}, 16))
+                    .addGroups(newPartitionerGroup("group3", new String[] {"tenant-4"}, 16))
                     .setDefaultGroupWeight(20)
                     .setName(profileName)
                     .build());

--- a/kafka-streams-partitioners/weighted-group-partitioner/src/test/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupPartitionerTest.java
+++ b/kafka-streams-partitioners/weighted-group-partitioner/src/test/java/org/hypertrace/core/kafkastreams/framework/partitioner/WeightedGroupPartitionerTest.java
@@ -235,7 +235,8 @@ public class WeightedGroupPartitionerTest {
     int testCount = numPartitions * 2;
     int lastPartitionSeen = -1;
 
-    WeightedGroupPartitioner<String, String> partitioner = getPartitionerForTestWithNonMultipleRoundingWeightRatio();
+    WeightedGroupPartitioner<String, String> partitioner =
+        getPartitionerForTestWithNonMultipleRoundingWeightRatio();
     int partition;
 
     // Test case 1: tenant-1 belong to group-1 (partitions: [0 to 22])
@@ -243,8 +244,8 @@ public class WeightedGroupPartitionerTest {
       partition = partitioner.partition("test-topic", "tenant-1", "span-" + i, numPartitions);
       if (partition > lastPartitionSeen) lastPartitionSeen = partition;
       assertTrue(
-              partition >= 0 && partition <= 22,
-              "actual partition not in expected range. partition: " + partition);
+          partition >= 0 && partition <= 22,
+          "actual partition not in expected range. partition: " + partition);
     }
 
     // Test case 2: tenant-2 belong to group-2 (partitions: [23 to 40])
@@ -252,8 +253,8 @@ public class WeightedGroupPartitionerTest {
       partition = partitioner.partition("test-topic", "tenant-2", "span-" + i, numPartitions);
       if (partition > lastPartitionSeen) lastPartitionSeen = partition;
       assertTrue(
-              partition >= 23 && partition <= 40,
-              "actual partition not in expected range. partition: " + partition);
+          partition >= 23 && partition <= 40,
+          "actual partition not in expected range. partition: " + partition);
     }
 
     // Test case 3: tenant-3 belong to group-2 (partitions: [23 to 40])
@@ -261,8 +262,8 @@ public class WeightedGroupPartitionerTest {
       partition = partitioner.partition("test-topic", "tenant-3", "span-" + i, numPartitions);
       if (partition > lastPartitionSeen) lastPartitionSeen = partition;
       assertTrue(
-              partition >= 23 && partition <= 40,
-              "actual partition not in expected range. partition: " + partition);
+          partition >= 23 && partition <= 40,
+          "actual partition not in expected range. partition: " + partition);
     }
 
     // Test case 4: groupKey=unknown should use default group [41 to 63]
@@ -270,28 +271,29 @@ public class WeightedGroupPartitionerTest {
       partition = partitioner.partition("test-topic", "unknown", "span-" + i, numPartitions);
       if (partition > lastPartitionSeen) lastPartitionSeen = partition;
       assertTrue(
-              partition >= 41 && partition <= 63,
-              "actual partition not in expected range. partition: " + partition);
+          partition >= 41 && partition <= 63,
+          "actual partition not in expected range. partition: " + partition);
     }
-    assertEquals(lastPartitionSeen,  numPartitions - 1);
+    assertEquals(lastPartitionSeen, numPartitions - 1);
   }
 
-  private WeightedGroupPartitioner<String, String> getPartitionerForTestWithNonMultipleRoundingWeightRatio() {
+  private WeightedGroupPartitioner<String, String>
+      getPartitionerForTestWithNonMultipleRoundingWeightRatio() {
     PartitionerConfigServiceClient testClient =
-            (profileName) ->
-                    new WeightedGroupProfile(
-                            PartitionerProfile.newBuilder()
-                                    .addGroups(newPartitionerGroup("group1", new String[] {"tenant-1"}, 37))
-                                    .addGroups(
-                                            newPartitionerGroup("group2", new String[] {"tenant-2", "tenant-3"}, 29))
-                                    .addGroups(newPartitionerGroup("group1", new String[] {"tenant-4"}, 16))
-                                    .setDefaultGroupWeight(20)
-                                    .setName(profileName)
-                                    .build());
+        (profileName) ->
+            new WeightedGroupProfile(
+                PartitionerProfile.newBuilder()
+                    .addGroups(newPartitionerGroup("group1", new String[] {"tenant-1"}, 37))
+                    .addGroups(
+                        newPartitionerGroup("group2", new String[] {"tenant-2", "tenant-3"}, 29))
+                    .addGroups(newPartitionerGroup("group1", new String[] {"tenant-4"}, 16))
+                    .setDefaultGroupWeight(20)
+                    .setName(profileName)
+                    .build());
 
     WeightedGroupPartitioner<String, String> partitioner =
-            new WeightedGroupPartitioner<>(
-                    "spans", testClient, groupKeyExtractor, roundRobinPartitioner);
+        new WeightedGroupPartitioner<>(
+            "spans", testClient, groupKeyExtractor, roundRobinPartitioner);
     return partitioner;
   }
 


### PR DESCRIPTION
## Description
This PR addresses an issue caused by floating-point rounding to integers, which was leading to the last partition being excluded in the partitioners.

For example, with the following configuration, the default partitioner groups the weight range as:  
- **Weight Range**: 0.8039215686274509 to 0.99999999999  

Due to the rounding issue at `0.99999999999`, only partitions **41 to 62** are included for this group, out of 64 total topic partitions.  

This PR fixes the rounding issue, ensuring all partitions are correctly included in the partitioner. 
```
{ 
      "name": "spans",
      "groups": [
        {
          "name": "dynamic-group-0",
          "memberIds": [
            "test-1"
          ],
          "weight": 37
        },
        {
          "name": "dynamic-group-1",
          "memberIds": [
            "test-2"
          ],
          "weight": 29
        },
        {
          "name": "dynamic-group-2",
          "memberIds": [
            "test-2"
          ],
          "weight": 16
        }
      ],
      "defaultGroupWeight": 20
    }
  ```


### Testing
see the test : testWithNonMultipleRoundingWeightRatio

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
