### PR TITLE
Add custom metrics in AbstractThrottledPunctuator to track total events in eventStore and if the yield condition is hit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
   id("org.hypertrace.publish-plugin") version "1.1.1" apply false
   id("org.hypertrace.jacoco-report-plugin") version "0.3.0" apply false
   id("org.hypertrace.code-style-plugin") version "2.1.2" apply false
-  id("org.owasp.dependencycheck") version "12.1.0"
+  id("org.owasp.dependencycheck") version "12.1.3"
 }
 
 subprojects {

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
     api("org.apache.kafka:kafka-clients:$confluentCcsVersion")
     api("org.apache.kafka:kafka-streams:$confluentCcsVersion")
     api("org.apache.kafka:kafka-streams-test-utils:$confluentCcsVersion")
-    api("org.apache.avro:avro:1.11.4")
+    api("org.apache.avro:avro:1.12.0")
   }
 }

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
     api("org.apache.commons:commons-compress:1.26.0") {
       because("https://www.tenable.com/cve/CVE-2024-25710")
     }
+    api("org.apache.commons:commons-lang3:3.18.0") {
+      because("CVE-2025-48924 is fixed in 3.18.0")
+    }
+
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")
     api("io.confluent:kafka-protobuf-serializer:$confluentVersion")

--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   api(platform(project(":kafka-bom")))
   api("org.apache.kafka:kafka-streams")
   api("io.confluent:kafka-streams-avro-serde")
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.14")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.16")
 
   implementation("org.apache.avro:avro")
   implementation("org.apache.kafka:kafka-clients")

--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
   implementation("org.apache.kafka:kafka-clients")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.89")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.89")
-  implementation("org.apache.commons:commons-lang3:3.12.0")
+  implementation("org.apache.commons:commons-lang3:3.18.0")
 
   testCompileOnly("org.projectlombok:lombok:1.18.26")
   testAnnotationProcessor("org.projectlombok:lombok:1.18.26")

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuator.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuator.java
@@ -141,7 +141,7 @@ public abstract class AbstractThrottledPunctuator<T> implements Punctuator {
     }
     long timeTakenMs = clock.millis() - startTime;
     boolean yielded = shouldYieldNow(startTime);
-    updateEventCountGauge(totalEventCount, yielded);
+    updateTotalEventCountGauge(totalEventCount, yielded);
 
     log.debug(
         "processed windows: {}, processed tasks: {}, total events: {}, time taken: {}ms",
@@ -169,7 +169,7 @@ public abstract class AbstractThrottledPunctuator<T> implements Punctuator {
     return timestamp - (timestamp % config.getWindowMs());
   }
 
-  private void updateEventCountGauge(int totalEventCount, boolean yielded) {
+  private void updateTotalEventCountGauge(int totalEventCount, boolean yielded) {
     if (meterRegistry == null) {
       return;
     }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuator.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuator.java
@@ -41,6 +41,11 @@ public abstract class AbstractThrottledPunctuator<T> implements Punctuator {
     this.meterRegistry = meterRegistry;
   }
 
+  public AbstractThrottledPunctuator(
+      Clock clock, ThrottledPunctuatorConfig config, KeyValueStore<Long, List<T>> eventStore) {
+    this(clock, config, eventStore, null);
+  }
+
   public void scheduleTask(long scheduleMs, T event) {
     long windowMs = normalize(scheduleMs);
     List<T> events = Optional.ofNullable(eventStore.get(windowMs)).orElse(new ArrayList<>());

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuatorTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuatorTest.java
@@ -194,7 +194,7 @@ class AbstractThrottledPunctuatorTest {
         Clock clock,
         ThrottledPunctuatorConfig config,
         KeyValueStore<Long, List<String>> objectStore) {
-      super(clock, config, objectStore);
+      super(clock, config, objectStore, null);
     }
 
     void setReturnResult(String object, TaskResult result) {

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuatorTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/punctuators/AbstractThrottledPunctuatorTest.java
@@ -194,7 +194,7 @@ class AbstractThrottledPunctuatorTest {
         Clock clock,
         ThrottledPunctuatorConfig config,
         KeyValueStore<Long, List<String>> objectStore) {
-      super(clock, config, objectStore, null);
+      super(clock, config, objectStore);
     }
 
     void setReturnResult(String object, TaskResult result) {

--- a/kafka-streams-partitioners/weighted-group-partitioner/build.gradle.kts
+++ b/kafka-streams-partitioners/weighted-group-partitioner/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
   api(platform(project(":kafka-bom")))
   api("org.apache.kafka:kafka-streams")
-  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.14")
+  api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.16")
   api("com.typesafe:config:1.4.2")
   implementation("com.google.guava:guava:32.0.1-jre")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.13.14")


### PR DESCRIPTION
## Description
 have added custom metrics to the `AbstractThrottledPunctuator` class to monitor the size of the punctuator task queue and whether the punctuator is processing tasks efficiently.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
