### PR TITLE
chore: bump a couple versions

### DIFF
--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 var confluentVersion = "7.7.0"
 var confluentCcsVersion = "$confluentVersion-ccs"
-var protobufVersion = "3.25.5"
+var protobufVersion = "3.25.8"
 
 dependencies {
   constraints {

--- a/kafka-streams-partitioners/weighted-group-partitioner/build.gradle.kts
+++ b/kafka-streams-partitioners/weighted-group-partitioner/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   api("org.hypertrace.core.grpcutils:grpc-client-utils:0.13.16")
   api("com.typesafe:config:1.4.2")
   implementation("com.google.guava:guava:32.0.1-jre")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.13.14")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.13.16")
   implementation("org.hypertrace.config.service:partitioner-config-service-api:0.1.73")
   implementation("org.slf4j:slf4j-api:1.7.36")
 


### PR DESCRIPTION
## Description
Bumping a couple of mismatched versions. Real reason for this change is to cut a new release after the prior release published an incomplete set of artifacts.