### PR TITLE
Try to fix transitive dependency conflict issue introduced at bom consumers.

### DIFF
--- a/.github/workflows/trivy-dependency-scan.yml
+++ b/.github/workflows/trivy-dependency-scan.yml
@@ -1,0 +1,50 @@
+name: Trivy Dependency Scan
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'kafka-bom/build.gradle.kts'
+      - '.github/workflows/trivy-dependency-scan.yml'
+
+jobs:
+  scan-kafka-clients:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Kafka Clients JAR
+        run: |
+          mkdir -p artifacts
+          curl -o artifacts/kafka-clients-7.9.5-ccs.jar \
+            https://packages.confluent.io/maven/org/apache/kafka/kafka-clients/7.9.5-ccs/kafka-clients-7.9.5-ccs.jar
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: 'artifacts/kafka-clients-7.9.5-ccs.jar'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Run Trivy vulnerability scanner (table output)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: 'artifacts/kafka-clients-7.9.5-ccs.jar'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/trivy-dependency-scan.yml
+++ b/.github/workflows/trivy-dependency-scan.yml
@@ -8,34 +8,30 @@ on:
       - '.github/workflows/trivy-dependency-scan.yml'
 
 jobs:
-  scan-kafka-clients:
+  build:
     runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      security-events: write
     steps:
-      - name: Checkout code
+      # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
+      - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
 
-      - name: Download Kafka Clients JAR
-        run: |
-          mkdir -p scan-context
-          curl -o scan-context/kafka-clients-7.9.5-ccs.jar \
-            https://packages.confluent.io/maven/org/apache/kafka/kafka-clients/7.9.5-ccs/kafka-clients-7.9.5-ccs.jar
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_READ_USER }}
+          password: ${{ secrets.DOCKERHUB_READ_TOKEN }}
 
-      - name: Create Dockerfile for scanning
-        run: |
-          cat > scan-context/Dockerfile <<EOF
-          FROM scratch
-          COPY kafka-clients-7.9.5-ccs.jar /
-          EOF
-
-      - name: Build Docker image
-        run: |
-          docker build -t kafka-clients-scan scan-context
+      - name: Build with Gradle
+        uses: hypertrace/github-actions/gradle@main
+        with:
+          args: assemble dockerBuildImages
 
       - name: Run Trivy vulnerability scanner
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
-          image: kafka-clients-scan
+          image: hypertrace/kafka-streams-framework
           output-mode: github

--- a/.github/workflows/trivy-dependency-scan.yml
+++ b/.github/workflows/trivy-dependency-scan.yml
@@ -1,9 +1,6 @@
 name: Trivy Dependency Scan
 
 on:
-  schedule:
-    # Run daily at 2 AM UTC
-    - cron: '0 2 * * *'
   workflow_dispatch:
   pull_request:
     paths:
@@ -27,24 +24,7 @@ jobs:
             https://packages.confluent.io/maven/org/apache/kafka/kafka-clients/7.9.5-ccs/kafka-clients-7.9.5-ccs.jar
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: hypertrace/github-actions/trivy-image-scan@main
         with:
-          scan-type: 'fs'
-          scan-ref: 'artifacts/kafka-clients-7.9.5-ccs.jar'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-
-      - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-
-      - name: Run Trivy vulnerability scanner (table output)
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'fs'
-          scan-ref: 'artifacts/kafka-clients-7.9.5-ccs.jar'
-          format: 'table'
-          severity: 'CRITICAL,HIGH'
+          image: artifacts/kafka-clients-7.9.5-ccs.jar
+          output-mode: github

--- a/.github/workflows/trivy-dependency-scan.yml
+++ b/.github/workflows/trivy-dependency-scan.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t kafka-clients-scan:latest scan-context
+          docker build -t kafka-clients-scan scan-context
 
       - name: Run Trivy vulnerability scanner
         uses: hypertrace/github-actions/trivy-image-scan@main

--- a/.github/workflows/trivy-dependency-scan.yml
+++ b/.github/workflows/trivy-dependency-scan.yml
@@ -32,10 +32,10 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t kafka-clients-scan:7.9.5-ccs scan-context
+          docker build -t kafka-clients-scan:latest scan-context
 
       - name: Run Trivy vulnerability scanner
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
-          image: kafka-clients-scan:7.9.5-ccs
+          image: kafka-clients-scan:latest
           output-mode: github

--- a/.github/workflows/trivy-dependency-scan.yml
+++ b/.github/workflows/trivy-dependency-scan.yml
@@ -19,12 +19,23 @@ jobs:
 
       - name: Download Kafka Clients JAR
         run: |
-          mkdir -p artifacts
-          curl -o artifacts/kafka-clients-7.9.5-ccs.jar \
+          mkdir -p scan-context
+          curl -o scan-context/kafka-clients-7.9.5-ccs.jar \
             https://packages.confluent.io/maven/org/apache/kafka/kafka-clients/7.9.5-ccs/kafka-clients-7.9.5-ccs.jar
+
+      - name: Create Dockerfile for scanning
+        run: |
+          cat > scan-context/Dockerfile <<EOF
+          FROM scratch
+          COPY kafka-clients-7.9.5-ccs.jar /
+          EOF
+
+      - name: Build Docker image
+        run: |
+          docker build -t kafka-clients-scan:7.9.5-ccs scan-context
 
       - name: Run Trivy vulnerability scanner
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
-          image: artifacts/kafka-clients-7.9.5-ccs.jar
+          image: kafka-clients-scan:7.9.5-ccs
           output-mode: github

--- a/.github/workflows/trivy-dependency-scan.yml
+++ b/.github/workflows/trivy-dependency-scan.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: hypertrace/github-actions/trivy-image-scan@main
         with:
-          image: kafka-clients-scan:latest
+          image: kafka-clients-scan
           output-mode: github

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,14 +29,13 @@ subprojects {
     }
   }
 
-  // Handle lz4-java redirect capability conflict:
-  // Sonatype added a redirect from org.lz4:lz4-java:1.8.1 -> at.yawk.lz4:lz4-java:1.8.1 to address CVE-2025-12183.
-  // Both artifacts declare the same capability, causing a conflict when upgrading from Kafka's org.lz4:lz4-java:1.8.0.
-  // This resolution strategy tells Gradle to automatically select the highest version when this conflict occurs.
+  // Replace org.lz4:lz4-java with at.yawk.lz4:lz4-java to handle Sonatype relocation
+  // This MUST be in each consuming repo - BOMs cannot enforce this automatically
   configurations.all {
-    resolutionStrategy.capabilitiesResolution.withCapability("org.lz4:lz4-java") {
-      select("at.yawk.lz4:lz4-java:1.8.1")
-      because("Both org.lz4 and at.yawk.lz4 provide lz4-java due to Sonatype redirect")
+    resolutionStrategy.dependencySubstitution {
+      substitute(module("org.lz4:lz4-java"))
+        .using(module("at.yawk.lz4:lz4-java:1.10.1"))
+        .because("org.lz4:lz4-java has been relocated to at.yawk.lz4:lz4-java to fix CVE-2025-12183")
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ subprojects {
   // This resolution strategy tells Gradle to automatically select the highest version when this conflict occurs.
   configurations.all {
     resolutionStrategy.capabilitiesResolution.withCapability("org.lz4:lz4-java") {
-      select("at.yawk.lz4:lz4-java:1.10.1")
+      select("at.yawk.lz4:lz4-java:1.8.1")
       because("Both org.lz4 and at.yawk.lz4 provide lz4-java due to Sonatype redirect")
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   id("org.hypertrace.jacoco-report-plugin") version "0.3.0" apply false
   id("org.hypertrace.code-style-plugin") version "2.1.2" apply false
   id("org.owasp.dependencycheck") version "12.1.3"
+  id("org.hypertrace.docker-java-application-plugin") version "0.11.3"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ subprojects {
   // This resolution strategy tells Gradle to automatically select the highest version when this conflict occurs.
   configurations.all {
     resolutionStrategy.capabilitiesResolution.withCapability("org.lz4:lz4-java") {
-      select("at.yawk.lz4:lz4-java:1.8.1")
+      select("at.yawk.lz4:lz4-java:1.10.1")
       because("Both org.lz4 and at.yawk.lz4 provide lz4-java due to Sonatype redirect")
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
   id("org.hypertrace.jacoco-report-plugin") version "0.3.0" apply false
   id("org.hypertrace.code-style-plugin") version "2.1.2" apply false
   id("org.owasp.dependencycheck") version "12.1.3"
-  id("org.hypertrace.docker-java-application-plugin") version "0.11.3"
+  id("org.hypertrace.docker-java-application-plugin") version "0.11.3" apply false
 }
 
 subprojects {

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     }
     api("at.yawk.lz4:lz4-java:1.10.1") {
       because("[https://nvd.nist.gov/vuln/detail/CVE-2025-66566] in at.yawk.lz4:lz4-java (lz4-java-1.8.1.jar)")
-      because("CVE-2025-66566 is fixed in 1.8.1")
+      because("CVE-2025-66566 is fixed in 1.10.1")
     }
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -25,9 +25,9 @@ dependencies {
     api("org.apache.commons:commons-lang3:3.18.0") {
       because("CVE-2025-48924 is fixed in 3.18.0")
     }
-    api("at.yawk.lz4:lz4-java:1.10.1") {
-      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-66566] in at.yawk.lz4:lz4-java (lz4-java-1.8.1.jar)")
-      because("CVE-2025-66566 is fixed in 1.8.1")
+    api("org.lz4:lz4-java:1.8.1") {
+      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-12183] in org.lz4:lz4-java:1.8.0")
+      because("CVE-2025-12183 is fixed in 1.8.1")
     }
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
   id("org.hypertrace.publish-plugin")
 }
 
-
 var confluentVersion = "7.9.5"
 var confluentCcsVersion = "$confluentVersion-ccs"
 var protobufVersion = "3.25.8"
@@ -24,10 +23,6 @@ dependencies {
     }
     api("org.apache.commons:commons-lang3:3.18.0") {
       because("CVE-2025-48924 is fixed in 3.18.0")
-    }
-    api("org.lz4:lz4-java:1.8.1") {
-      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-12183] in org.lz4:lz4-java:1.8.0")
-      because("CVE-2025-12183 is fixed in 1.8.1")
     }
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 
-var confluentVersion = "7.7.0"
+var confluentVersion = "7.9.5"
 var confluentCcsVersion = "$confluentVersion-ccs"
 var protobufVersion = "3.25.8"
 

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -25,10 +25,10 @@ dependencies {
     api("org.apache.commons:commons-lang3:3.18.0") {
       because("CVE-2025-48924 is fixed in 3.18.0")
     }
-    api("org.lz4:lz4-java:1.8.1") {
-      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-12183] in org.lz4:lz4-java:1.8.0")
-      because("CVE-2025-12183 is fixed in 1.8.1")
-    }
+//    api("org.lz4:lz4-java:1.8.1") {
+//      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-12183] in org.lz4:lz4-java:1.8.0")
+//      because("CVE-2025-12183 is fixed in 1.8.1")
+//    }
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")
     api("io.confluent:kafka-protobuf-serializer:$confluentVersion")

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -25,9 +25,9 @@ dependencies {
     api("org.apache.commons:commons-lang3:3.18.0") {
       because("CVE-2025-48924 is fixed in 3.18.0")
     }
-    api("org.lz4:lz4-java:1.8.1") {
-      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-12183] in org.lz4:lz4-java:1.8.0")
-      because("CVE-2025-12183 is fixed in 1.8.1")
+    api("at.yawk.lz4:lz4-java:1.10.1") {
+      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-66566] in at.yawk.lz4:lz4-java (lz4-java-1.8.1.jar)")
+      because("CVE-2025-66566 is fixed in 1.8.1")
     }
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     }
     api("at.yawk.lz4:lz4-java:1.10.1") {
       because("[https://nvd.nist.gov/vuln/detail/CVE-2025-66566] in at.yawk.lz4:lz4-java (lz4-java-1.8.1.jar)")
-      because("CVE-2025-66566 is fixed in 1.10.1")
+      because("CVE-2025-66566 is fixed in 1.8.1")
     }
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")

--- a/kafka-bom/build.gradle.kts
+++ b/kafka-bom/build.gradle.kts
@@ -25,10 +25,10 @@ dependencies {
     api("org.apache.commons:commons-lang3:3.18.0") {
       because("CVE-2025-48924 is fixed in 3.18.0")
     }
-//    api("org.lz4:lz4-java:1.8.1") {
-//      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-12183] in org.lz4:lz4-java:1.8.0")
-//      because("CVE-2025-12183 is fixed in 1.8.1")
-//    }
+    api("org.lz4:lz4-java:1.8.1") {
+      because("[https://nvd.nist.gov/vuln/detail/CVE-2025-12183] in org.lz4:lz4-java:1.8.0")
+      because("CVE-2025-12183 is fixed in 1.8.1")
+    }
 
     api("io.confluent:kafka-streams-avro-serde:$confluentVersion")
     api("io.confluent:kafka-protobuf-serializer:$confluentVersion")

--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   id("org.hypertrace.publish-plugin")
   id("org.hypertrace.jacoco-report-plugin")
   id("org.hypertrace.avro-plugin")
+  id("org.hypertrace.docker-java-application-plugin")
 }
 
 tasks.test {


### PR DESCRIPTION
I want to test whether the resolutionStrategy is enough to constraint lz4, and whether it can avoid the dependency conflict due to the redirect from org.lz4:lz4-java:1.8.1 to at.yawk.lz4.

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
