### PR TITLE
Auto-size num.stream.threads from topology and replica count

### DIFF
--- a/kafka-streams-framework/build.gradle.kts
+++ b/kafka-streams-framework/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   testImplementation(commonLibs.junit.jupiter)
   testImplementation(localLibs.junit.pioneer)
   testImplementation(commonLibs.mockito.core)
+  testImplementation(commonLibs.mockito.junit)
   testImplementation(localLibs.hamcrest.core)
   testRuntimeOnly(commonLibs.log4j.slf4j2.impl)
 }

--- a/kafka-streams-framework/gradle.lockfile
+++ b/kafka-streams-framework/gradle.lockfile
@@ -119,6 +119,7 @@ org.junit:junit-bom:5.10.0=testCompileClasspath
 org.junit:junit-bom:5.11.2=testRuntimeClasspath
 org.latencyutils:LatencyUtils:2.0.3=runtimeClasspath,testRuntimeClasspath
 org.mockito:mockito-core:5.8.0=testCompileClasspath,testRuntimeClasspath
+org.mockito:mockito-junit-jupiter:5.8.0=testCompileClasspath,testRuntimeClasspath
 org.objenesis:objenesis:3.3=testRuntimeClasspath
 org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
 org.projectlombok:lombok:1.18.30=annotationProcessor,compileClasspath,testCompileClasspath

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -110,8 +109,9 @@ public abstract class KafkaStreamsApp extends PlatformService {
       streamsBuilder = buildTopology(streamsConfig, streamsBuilder, sourceStreams);
       this.topology = streamsBuilder.build();
 
-      resolveDynamicStreamThreads(streamsConfig)
-          .ifPresent(threads -> streamsConfig.put(NUM_STREAM_THREADS_CONFIG, threads));
+      if (StreamThreadsCountResolver.isDynamic(streamsConfig)) {
+        streamsConfig.put(NUM_STREAM_THREADS_CONFIG, resolveDynamicStreamThreads(streamsConfig));
+      }
 
       getLogger().info("Finalized kafka streams configuration: {}", streamsConfig);
 
@@ -292,31 +292,31 @@ public abstract class KafkaStreamsApp extends PlatformService {
     return Optional.empty();
   }
 
-  // Defensive: any unexpected runtime failure in dynamic resolution must NOT prevent the app from
-  // starting. If something goes wrong, log and return empty so the caller leaves the streams
-  // config untouched. JVM Errors (OOM, LinkageError, etc.) propagate — those are not recoverable.
-  private OptionalInt resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
+  // Caller must check StreamThreadsCountResolver.isDynamic(...) before invoking. Always returns
+  // a concrete value: either the resolver's computed count or FALLBACK_NUM_STREAM_THREADS.
+  // The string sentinel "DYNAMIC" must never leak back to Kafka Streams config — it can't be
+  // parsed as an integer.
+  private int resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
+    Optional<StreamThreadsCountResolver> resolver;
     try {
-      if (!StreamThreadsCountResolver.isDynamic(streamsProperties)) {
-        return OptionalInt.empty();
-      }
-      Optional<StreamThreadsCountResolver> resolver = getStreamThreadsCountResolver();
-      if (resolver.isEmpty()) {
-        getLogger()
-            .warn(
-                "{} is set to DYNAMIC but no StreamThreadsCountResolver is provided; leaving as-is",
-                NUM_STREAM_THREADS_CONFIG);
-        return OptionalInt.empty();
-      }
-      return OptionalInt.of(resolver.get().resolve(this.topology, streamsProperties));
+      resolver = getStreamThreadsCountResolver();
     } catch (Exception exception) {
       getLogger()
-          .error(
-              "Unexpected error resolving dynamic {}; leaving config untouched",
-              NUM_STREAM_THREADS_CONFIG,
+          .warn(
+              "getStreamThreadsCountResolver() threw; falling back to {} stream threads",
+              StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS,
               exception);
-      return OptionalInt.empty();
+      return StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS;
     }
+    if (resolver.isEmpty()) {
+      getLogger()
+          .warn(
+              "{} is set to DYNAMIC but no StreamThreadsCountResolver is provided; falling back to {}",
+              NUM_STREAM_THREADS_CONFIG,
+              StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS);
+      return StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS;
+    }
+    return resolver.get().resolve(this.topology, streamsProperties);
   }
 
   public Map<String, Object> getStreamsConfig(Config jobConfig) {

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -109,7 +110,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
       streamsBuilder = buildTopology(streamsConfig, streamsBuilder, sourceStreams);
       this.topology = streamsBuilder.build();
 
-      resolveDynamicStreamThreads(streamsConfig);
+      resolveDynamicStreamThreads(streamsConfig)
+          .ifPresent(threads -> streamsConfig.put(NUM_STREAM_THREADS_CONFIG, threads));
 
       getLogger().info("Finalized kafka streams configuration: {}", streamsConfig);
 
@@ -290,13 +292,13 @@ public abstract class KafkaStreamsApp extends PlatformService {
     return Optional.empty();
   }
 
-  // Defensive: any unexpected failure in dynamic resolution must NOT prevent the app from starting.
-  // If something goes wrong, log and leave streamsProperties untouched so Kafka Streams uses
-  // whatever value was originally configured (or its own default).
-  private void resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
+  // Defensive: any unexpected runtime failure in dynamic resolution must NOT prevent the app from
+  // starting. If something goes wrong, log and return empty so the caller leaves the streams
+  // config untouched. JVM Errors (OOM, LinkageError, etc.) propagate — those are not recoverable.
+  private OptionalInt resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
     try {
       if (!StreamThreadsCountResolver.isDynamic(streamsProperties)) {
-        return;
+        return OptionalInt.empty();
       }
       Optional<StreamThreadsCountResolver> resolver = getStreamThreadsCountResolver();
       if (resolver.isEmpty()) {
@@ -304,16 +306,16 @@ public abstract class KafkaStreamsApp extends PlatformService {
             .warn(
                 "{} is set to DYNAMIC but no StreamThreadsCountResolver is provided; leaving as-is",
                 NUM_STREAM_THREADS_CONFIG);
-        return;
+        return OptionalInt.empty();
       }
-      int resolved = resolver.get().resolve(this.topology, streamsProperties);
-      streamsProperties.put(NUM_STREAM_THREADS_CONFIG, resolved);
-    } catch (Throwable throwable) {
+      return OptionalInt.of(resolver.get().resolve(this.topology, streamsProperties));
+    } catch (Exception exception) {
       getLogger()
           .error(
               "Unexpected error resolving dynamic {}; leaving config untouched",
               NUM_STREAM_THREADS_CONFIG,
-              throwable);
+              exception);
+      return OptionalInt.empty();
     }
   }
 

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -288,16 +288,24 @@ public abstract class KafkaStreamsApp extends PlatformService {
    *           StreamThreadsCountResolver.optionalReplicaCount(replicaCount)));
    * }
    * }</pre>
+   *
+   * <p>Fallback to {@link StreamThreadsCountResolver#FALLBACK_NUM_STREAM_THREADS} occurs when:
+   *
+   * <ul>
+   *   <li>{@code num.stream.threads} is set to {@code DYNAMIC} but this method returns empty
+   *   <li>this method itself throws
+   *   <li>replica count supplied to the resolver is non-positive (env var unset/zero/negative)
+   *   <li>the AdminClient/calculator call throws (broker unreachable, describe timeout, etc.)
+   *   <li>the topology contains a regex/pattern source — partitions cannot be enumerated up-front
+   * </ul>
    */
   protected Optional<StreamThreadsCountResolver> getStreamThreadsCountResolver() {
     return Optional.empty();
   }
 
   // Caller must check StreamThreadsCountResolver.isDynamic(...) before invoking. Always returns a
-  // concrete int — every "cannot resolve" path (resolver-supplier throws, no resolver wired,
-  // resolver returns empty for unsupported topologies / non-positive replicas / AdminClient
-  // failure) collapses to FALLBACK_NUM_STREAM_THREADS so the literal "DYNAMIC" sentinel never
-  // reaches Kafka Streams.
+  // concrete int so the literal "DYNAMIC" sentinel never reaches Kafka Streams config — see
+  // getStreamThreadsCountResolver() javadoc for the full list of fallback triggers.
   private int resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
     Optional<StreamThreadsCountResolver> resolver;
     try {

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -16,6 +16,7 @@ import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CON
 import static org.apache.kafka.streams.StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION;
 import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -49,6 +51,7 @@ import org.hypertrace.core.grpcutils.client.GrpcRegistryConfig;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateListener;
 import org.hypertrace.core.kafkastreams.framework.listeners.LoggingStateRestoreListener;
 import org.hypertrace.core.kafkastreams.framework.rocksdb.BoundedMemoryConfigSetter;
+import org.hypertrace.core.kafkastreams.framework.threading.StreamThreadsCountResolver;
 import org.hypertrace.core.kafkastreams.framework.timestampextractors.UseWallclockTimeOnInvalidTimestamp;
 import org.hypertrace.core.kafkastreams.framework.topics.creator.KafkaTopicCreator;
 import org.hypertrace.core.kafkastreams.framework.util.ExceptionUtils;
@@ -105,6 +108,8 @@ public abstract class KafkaStreamsApp extends PlatformService {
       StreamsBuilder streamsBuilder = new StreamsBuilder();
       streamsBuilder = buildTopology(streamsConfig, streamsBuilder, sourceStreams);
       this.topology = streamsBuilder.build();
+
+      resolveDynamicStreamThreads(streamsConfig);
 
       getLogger().info("Finalized kafka streams configuration: {}", streamsConfig);
 
@@ -256,6 +261,43 @@ public abstract class KafkaStreamsApp extends PlatformService {
       Map<String, Object> streamsConfig,
       StreamsBuilder streamsBuilder,
       Map<String, KStream<?, ?>> sourceStreams);
+
+  /**
+   * Override in subclasses that want auto-sized {@code num.stream.threads}. Return a resolver
+   * configured with this app's replica count source. The framework only invokes this when {@code
+   * num.stream.threads} is set to {@link StreamThreadsCountResolver#DYNAMIC_SENTINEL}; returning an
+   * empty optional disables dynamic resolution and the app keeps whatever value was configured.
+   */
+  protected Optional<StreamThreadsCountResolver> getStreamThreadsCountResolver() {
+    return Optional.empty();
+  }
+
+  // Defensive: any unexpected failure in dynamic resolution must NOT prevent the app from starting.
+  // If something goes wrong, log and leave streamsProperties untouched so Kafka Streams uses
+  // whatever value was originally configured (or its own default).
+  private void resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
+    try {
+      if (!StreamThreadsCountResolver.isDynamic(streamsProperties)) {
+        return;
+      }
+      Optional<StreamThreadsCountResolver> resolver = getStreamThreadsCountResolver();
+      if (resolver.isEmpty()) {
+        getLogger()
+            .warn(
+                "{} is set to DYNAMIC but no StreamThreadsCountResolver is provided; leaving as-is",
+                NUM_STREAM_THREADS_CONFIG);
+        return;
+      }
+      int resolved = resolver.get().resolve(this.topology, streamsProperties);
+      streamsProperties.put(NUM_STREAM_THREADS_CONFIG, resolved);
+    } catch (Throwable throwable) {
+      getLogger()
+          .error(
+              "Unexpected error resolving dynamic {}; leaving config untouched",
+              NUM_STREAM_THREADS_CONFIG,
+              throwable);
+    }
+  }
 
   public Map<String, Object> getStreamsConfig(Config jobConfig) {
     return new HashMap<>(ConfigUtils.getFlatMapConfig(jobConfig, getStreamsConfigKey()));

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -264,9 +264,27 @@ public abstract class KafkaStreamsApp extends PlatformService {
 
   /**
    * Override in subclasses that want auto-sized {@code num.stream.threads}. Return a resolver
-   * configured with this app's replica count source. The framework only invokes this when {@code
+   * configured with this app's replica-count source. The framework only invokes this when {@code
    * num.stream.threads} is set to {@link StreamThreadsCountResolver#DYNAMIC_SENTINEL}; returning an
    * empty optional disables dynamic resolution and the app keeps whatever value was configured.
+   *
+   * <p>Apps that don't override this are unaffected — the default returns {@code Optional.empty()}
+   * and the framework leaves {@code num.stream.threads} exactly as configured. Apps that do
+   * override should supply replica count from wherever the deployment exposes it (e.g. the {@code
+   * REPLICA_COUNT} environment variable injected by the k8s template, or a HOCON config key).
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * @Override
+   * protected Optional<StreamThreadsCountResolver> getStreamThreadsCountResolver() {
+   *   final Optional<Integer> replicaCount =
+   *       ConfigUtils.optionalInteger(getAppConfig(), "replica.count");
+   *   return Optional.of(
+   *       new StreamThreadsCountResolver(
+   *           StreamThreadsCountResolver.optionalReplicaCount(replicaCount)));
+   * }
+   * }</pre>
    */
   protected Optional<StreamThreadsCountResolver> getStreamThreadsCountResolver() {
     return Optional.empty();

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -292,10 +293,11 @@ public abstract class KafkaStreamsApp extends PlatformService {
     return Optional.empty();
   }
 
-  // Caller must check StreamThreadsCountResolver.isDynamic(...) before invoking. Always returns
-  // a concrete value: either the resolver's computed count or FALLBACK_NUM_STREAM_THREADS.
-  // The string sentinel "DYNAMIC" must never leak back to Kafka Streams config — it can't be
-  // parsed as an integer.
+  // Caller must check StreamThreadsCountResolver.isDynamic(...) before invoking. Always returns a
+  // concrete int — every "cannot resolve" path (resolver-supplier throws, no resolver wired,
+  // resolver returns empty for unsupported topologies / non-positive replicas / AdminClient
+  // failure) collapses to FALLBACK_NUM_STREAM_THREADS so the literal "DYNAMIC" sentinel never
+  // reaches Kafka Streams.
   private int resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
     Optional<StreamThreadsCountResolver> resolver;
     try {
@@ -316,7 +318,14 @@ public abstract class KafkaStreamsApp extends PlatformService {
               StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS);
       return StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS;
     }
-    return resolver.get().resolve(this.topology, streamsProperties);
+    final OptionalInt resolved = resolver.get().resolve(this.topology, streamsProperties);
+    if (resolved.isEmpty()) {
+      getLogger()
+          .warn(
+              "Resolver could not compute dynamic num.stream.threads; falling back to {}",
+              StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS);
+    }
+    return resolved.orElse(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS);
   }
 
   public Map<String, Object> getStreamsConfig(Config jobConfig) {

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/KafkaStreamsApp.java
@@ -69,6 +69,16 @@ public abstract class KafkaStreamsApp extends PlatformService {
   public static final String CLEANUP_LOCAL_STATE = "cleanup.local.state";
   public static final String PRE_CREATE_TOPICS = "precreate.topics";
   public static final String KAFKA_STREAMS_CONFIG_KEY = "kafka.streams.config";
+
+  /**
+   * Framework-level boolean opt-in (set in the streams config map) that gates dynamic {@code
+   * num.stream.threads} resolution. Apps must also override {@link
+   * #getStreamThreadsCountResolver()}; this flag exists separately so deployments can roll out and
+   * roll back per-cluster without code changes. The flag is consumed by the framework before the
+   * config reaches Kafka Streams and is not a Kafka config key.
+   */
+  public static final String DYNAMIC_NUM_STREAM_THREADS_CONFIG = "dynamic.num.stream.threads";
+
   private static final String SHUTDOWN_DURATION = "shutdown.duration";
   private static final Logger logger = LoggerFactory.getLogger(KafkaStreamsApp.class);
 
@@ -110,8 +120,15 @@ public abstract class KafkaStreamsApp extends PlatformService {
       streamsBuilder = buildTopology(streamsConfig, streamsBuilder, sourceStreams);
       this.topology = streamsBuilder.build();
 
-      if (StreamThreadsCountResolver.isDynamic(streamsConfig)) {
-        streamsConfig.put(NUM_STREAM_THREADS_CONFIG, resolveDynamicStreamThreads(streamsConfig));
+      // Strip the dynamic-resolution flag before it reaches Kafka Streams (it's a framework-level
+      // opt-in, not a Kafka config). When enabled and a resolver is wired up, replace the
+      // configured num.stream.threads with the dynamically-computed value; otherwise the
+      // configured value flows through unchanged.
+      final boolean dynamicEnabled = isDynamicNumStreamThreadsEnabled(streamsConfig);
+      streamsConfig.remove(DYNAMIC_NUM_STREAM_THREADS_CONFIG);
+      if (dynamicEnabled) {
+        resolveDynamicStreamThreads(streamsConfig)
+            .ifPresent(threads -> streamsConfig.put(NUM_STREAM_THREADS_CONFIG, threads));
       }
 
       getLogger().info("Finalized kafka streams configuration: {}", streamsConfig);
@@ -267,9 +284,9 @@ public abstract class KafkaStreamsApp extends PlatformService {
 
   /**
    * Override in subclasses that want auto-sized {@code num.stream.threads}. Return a resolver
-   * configured with this app's replica-count source. The framework only invokes this when {@code
-   * num.stream.threads} is set to {@link StreamThreadsCountResolver#DYNAMIC_SENTINEL}; returning an
-   * empty optional disables dynamic resolution and the app keeps whatever value was configured.
+   * configured with this app's replica-count source. The framework only invokes this when {@link
+   * #DYNAMIC_NUM_STREAM_THREADS_CONFIG} is {@code true} in the streams config; returning an empty
+   * optional (the default) disables dynamic resolution.
    *
    * <p>Apps that don't override this are unaffected — the default returns {@code Optional.empty()}
    * and the framework leaves {@code num.stream.threads} exactly as configured. Apps that do
@@ -289,51 +306,54 @@ public abstract class KafkaStreamsApp extends PlatformService {
    * }
    * }</pre>
    *
-   * <p>Fallback to {@link StreamThreadsCountResolver#FALLBACK_NUM_STREAM_THREADS} occurs when:
+   * <p>The configured numeric {@code num.stream.threads} flows through unchanged when:
    *
    * <ul>
-   *   <li>{@code num.stream.threads} is set to {@code DYNAMIC} but this method returns empty
-   *   <li>this method itself throws
-   *   <li>replica count supplied to the resolver is non-positive (env var unset/zero/negative)
-   *   <li>the AdminClient/calculator call throws (broker unreachable, describe timeout, etc.)
-   *   <li>the topology contains a regex/pattern source — partitions cannot be enumerated up-front
+   *   <li>{@link #DYNAMIC_NUM_STREAM_THREADS_CONFIG} is {@code false} or unset
+   *   <li>this method returns empty (no resolver wired up)
+   *   <li>this method throws
+   *   <li>the resolver returns empty: replica count is non-positive, the AdminClient/calculator
+   *       call throws, the topology contains a regex/pattern source, or no source partitions are
+   *       resolvable on the broker
    * </ul>
    */
   protected Optional<StreamThreadsCountResolver> getStreamThreadsCountResolver() {
     return Optional.empty();
   }
 
-  // Caller must check StreamThreadsCountResolver.isDynamic(...) before invoking. Always returns a
-  // concrete int so the literal "DYNAMIC" sentinel never reaches Kafka Streams config — see
-  // getStreamThreadsCountResolver() javadoc for the full list of fallback triggers.
-  private int resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
-    Optional<StreamThreadsCountResolver> resolver;
+  // Caller must check the dynamic-enabled flag before invoking. Returns OptionalInt.empty() when
+  // no resolver is wired or resolution cannot produce a value — caller keeps the configured
+  // num.stream.threads as the fallback.
+  private OptionalInt resolveDynamicStreamThreads(Map<String, Object> streamsProperties) {
+    final Optional<StreamThreadsCountResolver> resolver;
     try {
       resolver = getStreamThreadsCountResolver();
     } catch (Exception exception) {
       getLogger()
           .warn(
-              "getStreamThreadsCountResolver() threw; falling back to {} stream threads",
-              StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS,
+              "getStreamThreadsCountResolver() threw; keeping configured num.stream.threads",
               exception);
-      return StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS;
+      return OptionalInt.empty();
     }
     if (resolver.isEmpty()) {
       getLogger()
           .warn(
-              "{} is set to DYNAMIC but no StreamThreadsCountResolver is provided; falling back to {}",
-              NUM_STREAM_THREADS_CONFIG,
-              StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS);
-      return StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS;
+              "{} is true but no StreamThreadsCountResolver is provided; keeping configured num.stream.threads",
+              DYNAMIC_NUM_STREAM_THREADS_CONFIG);
+      return OptionalInt.empty();
     }
     final OptionalInt resolved = resolver.get().resolve(this.topology, streamsProperties);
     if (resolved.isEmpty()) {
       getLogger()
-          .warn(
-              "Resolver could not compute dynamic num.stream.threads; falling back to {}",
-              StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS);
+          .warn("Resolver could not compute dynamic num.stream.threads; keeping configured value");
     }
-    return resolved.orElse(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS);
+    return resolved;
+  }
+
+  private static boolean isDynamicNumStreamThreadsEnabled(
+      final Map<String, Object> streamsProperties) {
+    final Object value = streamsProperties.get(DYNAMIC_NUM_STREAM_THREADS_CONFIG);
+    return value != null && Boolean.parseBoolean(String.valueOf(value));
   }
 
   public Map<String, Object> getStreamsConfig(Config jobConfig) {

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
@@ -29,6 +29,9 @@ import org.slf4j.LoggerFactory;
  * <p>For each sub-topology the maximum partition count across its source topics is the number of
  * stream tasks. Summing across sub-topologies and dividing by the replica count yields the threads
  * each instance should run to keep all tasks active without idle threads.
+ *
+ * <p>Regex/pattern subscriptions ({@link Source#topicPattern()}) are not supported — those
+ * sub-topologies contribute zero tasks. No current app subscribes via regex.
  */
 public class DynamicStreamThreadsCountCalculator {
 
@@ -93,13 +96,19 @@ public class DynamicStreamThreadsCountCalculator {
       return Map.of();
     }
     final DescribeTopicsResult result = adminClient.describeTopics(topics);
+    final Map<String, KafkaFuture<TopicDescription>> futures = result.topicNameValues();
+
+    // Single shared deadline across all topics — worst-case wait is one timeout, not N.
+    // AdminClient retries the underlying RPC internally per its own retry config.
+    awaitAll(futures.values(), DESCRIBE_TOPICS_TIMEOUT_MILLIS);
+
     final Map<String, Integer> partitions = new HashMap<>();
-    for (final Entry<String, KafkaFuture<TopicDescription>> entry :
-        result.topicNameValues().entrySet()) {
+    for (final Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
       try {
-        final TopicDescription description =
-            entry.getValue().get(DESCRIBE_TOPICS_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-        partitions.put(entry.getKey(), description.partitions().size());
+        // Non-blocking after awaitAll: each future is already complete (or completed
+        // exceptionally). Per-topic handling stays so UnknownTopicOrPartitionException
+        // doesn't fail the whole batch.
+        partitions.put(entry.getKey(), entry.getValue().get().partitions().size());
       } catch (final ExecutionException executionException) {
         if (executionException.getCause() instanceof UnknownTopicOrPartitionException) {
           logger.warn(
@@ -114,11 +123,25 @@ public class DynamicStreamThreadsCountCalculator {
         Thread.currentThread().interrupt();
         throw new RuntimeException(
             "Interrupted while describing topic " + entry.getKey(), interruptedException);
-      } catch (final TimeoutException timeoutException) {
-        throw new RuntimeException(
-            "Timed out describing topic " + entry.getKey(), timeoutException);
       }
     }
     return Map.copyOf(partitions);
+  }
+
+  private static void awaitAll(
+      final java.util.Collection<KafkaFuture<TopicDescription>> futures, final long timeoutMillis) {
+    try {
+      KafkaFuture.allOf(futures.toArray(KafkaFuture[]::new))
+          .get(timeoutMillis, TimeUnit.MILLISECONDS);
+    } catch (final TimeoutException timeoutException) {
+      throw new RuntimeException(
+          "Timed out describing topics after " + timeoutMillis + "ms", timeoutException);
+    } catch (final InterruptedException interruptedException) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted describing topics", interruptedException);
+    } catch (final ExecutionException executionException) {
+      // At least one topic future completed exceptionally; per-future handling below classifies
+      // (UnknownTopicOrPartitionException → 0 partitions; everything else → fail).
+    }
   }
 }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -30,8 +31,10 @@ import org.slf4j.LoggerFactory;
  * stream tasks. Summing across sub-topologies and dividing by the replica count yields the threads
  * each instance should run to keep all tasks active without idle threads.
  *
- * <p>Regex/pattern subscriptions ({@link Source#topicPattern()}) are not supported — those
- * sub-topologies contribute zero tasks. No current app subscribes via regex.
+ * <p>Returns {@link OptionalInt#empty()} when the topology contains a regex/pattern subscription
+ * ({@link Source#topicPattern()}) — those sub-topologies cannot be enumerated against the broker
+ * up-front, so dynamic sizing would silently under-count tasks. The caller falls back to its
+ * configured default in that case.
  */
 public class DynamicStreamThreadsCountCalculator {
 
@@ -47,12 +50,33 @@ public class DynamicStreamThreadsCountCalculator {
         .collect(toUnmodifiableSet());
   }
 
-  public int compute(final Topology topology, final AdminClient adminClient, final int replicas) {
+  private static boolean hasPatternSource(final Subtopology subtopology) {
+    return subtopology.nodes().stream()
+        .filter(node -> node instanceof Source)
+        .map(node -> (Source) node)
+        .anyMatch(source -> source.topicPattern() != null);
+  }
+
+  public OptionalInt compute(
+      final Topology topology, final AdminClient adminClient, final int replicas) {
     if (replicas <= 0) {
       throw new IllegalArgumentException("replicas must be positive, got " + replicas);
     }
 
     final TopologyDescription description = topology.describe();
+
+    // Bail out if any sub-topology subscribes via regex — topicSet() is empty for those, so
+    // dynamic sizing would silently under-count tasks. The caller substitutes its fallback.
+    final boolean anyPatternSource =
+        description.subtopologies().stream()
+            .anyMatch(DynamicStreamThreadsCountCalculator::hasPatternSource);
+    if (anyPatternSource) {
+      logger.warn(
+          "Topology contains a regex/pattern source; dynamic num.stream.threads is not supported. "
+              + "Caller will fall back to its configured default.");
+      return OptionalInt.empty();
+    }
+
     final Set<String> sourceTopics =
         description.subtopologies().stream()
             .flatMap(subtopology -> sourceTopicsOf(subtopology).stream())
@@ -87,9 +111,12 @@ public class DynamicStreamThreadsCountCalculator {
         subtopologyCount,
         replicas,
         threads);
-    return threads;
+    return OptionalInt.of(threads);
   }
 
+  // Single-loop implementation: AdminClient.describeTopics() already fires all RPCs concurrently
+  // before returning futures, so iteration here only consumes a shared deadline (now+timeout) —
+  // total wall-clock is capped at DESCRIBE_TOPICS_TIMEOUT_MILLIS regardless of topic count.
   private Map<String, Integer> describePartitions(
       final AdminClient adminClient, final Set<String> topics) {
     if (topics.isEmpty()) {
@@ -97,18 +124,26 @@ public class DynamicStreamThreadsCountCalculator {
     }
     final DescribeTopicsResult result = adminClient.describeTopics(topics);
     final Map<String, KafkaFuture<TopicDescription>> futures = result.topicNameValues();
-
-    // Single shared deadline across all topics — worst-case wait is one timeout, not N.
-    // AdminClient retries the underlying RPC internally per its own retry config.
-    awaitAll(futures.values(), DESCRIBE_TOPICS_TIMEOUT_MILLIS);
-
+    final long deadlineMillis = System.currentTimeMillis() + DESCRIBE_TOPICS_TIMEOUT_MILLIS;
     final Map<String, Integer> partitions = new HashMap<>();
+
     for (final Entry<String, KafkaFuture<TopicDescription>> entry : futures.entrySet()) {
+      final long remainingMillis = deadlineMillis - System.currentTimeMillis();
+      if (remainingMillis <= 0) {
+        throw new RuntimeException(
+            "Timed out describing topics after " + DESCRIBE_TOPICS_TIMEOUT_MILLIS + "ms");
+      }
       try {
-        // Non-blocking after awaitAll: each future is already complete (or completed
-        // exceptionally). Per-topic handling stays so UnknownTopicOrPartitionException
-        // doesn't fail the whole batch.
-        partitions.put(entry.getKey(), entry.getValue().get().partitions().size());
+        partitions.put(
+            entry.getKey(),
+            entry.getValue().get(remainingMillis, TimeUnit.MILLISECONDS).partitions().size());
+      } catch (final TimeoutException timeoutException) {
+        throw new RuntimeException(
+            "Timed out describing topic " + entry.getKey(), timeoutException);
+      } catch (final InterruptedException interruptedException) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(
+            "Interrupted while describing topic " + entry.getKey(), interruptedException);
       } catch (final ExecutionException executionException) {
         if (executionException.getCause() instanceof UnknownTopicOrPartitionException) {
           logger.warn(
@@ -119,29 +154,8 @@ public class DynamicStreamThreadsCountCalculator {
           throw new RuntimeException(
               "Failed to describe topic " + entry.getKey(), executionException);
         }
-      } catch (final InterruptedException interruptedException) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(
-            "Interrupted while describing topic " + entry.getKey(), interruptedException);
       }
     }
     return Map.copyOf(partitions);
-  }
-
-  private static void awaitAll(
-      final java.util.Collection<KafkaFuture<TopicDescription>> futures, final long timeoutMillis) {
-    try {
-      KafkaFuture.allOf(futures.toArray(KafkaFuture[]::new))
-          .get(timeoutMillis, TimeUnit.MILLISECONDS);
-    } catch (final TimeoutException timeoutException) {
-      throw new RuntimeException(
-          "Timed out describing topics after " + timeoutMillis + "ms", timeoutException);
-    } catch (final InterruptedException interruptedException) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted describing topics", interruptedException);
-    } catch (final ExecutionException executionException) {
-      // At least one topic future completed exceptionally; per-future handling below classifies
-      // (UnknownTopicOrPartitionException → 0 partitions; everything else → fail).
-    }
   }
 }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
@@ -104,7 +104,14 @@ public class DynamicStreamThreadsCountCalculator {
       totalTasks += tasksForSubtopology;
     }
 
-    final int threads = totalTasks == 0 ? 1 : (int) Math.ceil((double) totalTasks / replicas);
+    if (totalTasks == 0) {
+      logger.warn(
+          "No resolvable partitions across {} sub-topologies; skipping dynamic num.stream.threads.",
+          subtopologyCount);
+      return OptionalInt.empty();
+    }
+
+    final int threads = (int) Math.ceil((double) totalTasks / replicas);
     logger.info(
         "Dynamic num.stream.threads: totalTasks={} across {} sub-topologies, replicas={}, computed={}",
         totalTasks,

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculator.java
@@ -1,0 +1,124 @@
+package org.hypertrace.core.kafkastreams.framework.threading;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.Source;
+import org.apache.kafka.streams.TopologyDescription.Subtopology;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Computes a per-instance {@code num.stream.threads} value from a topology and the partition count
+ * of every source topic.
+ *
+ * <p>For each sub-topology the maximum partition count across its source topics is the number of
+ * stream tasks. Summing across sub-topologies and dividing by the replica count yields the threads
+ * each instance should run to keep all tasks active without idle threads.
+ */
+public class DynamicStreamThreadsCountCalculator {
+
+  private static final long DESCRIBE_TOPICS_TIMEOUT_MILLIS = Duration.ofSeconds(5).toMillis();
+  private static final Logger logger =
+      LoggerFactory.getLogger(DynamicStreamThreadsCountCalculator.class);
+
+  private static Set<String> sourceTopicsOf(final Subtopology subtopology) {
+    return subtopology.nodes().stream()
+        .filter(node -> node instanceof Source)
+        .map(node -> (Source) node)
+        .flatMap(source -> source.topicSet().stream())
+        .collect(toUnmodifiableSet());
+  }
+
+  public int compute(final Topology topology, final AdminClient adminClient, final int replicas) {
+    if (replicas <= 0) {
+      throw new IllegalArgumentException("replicas must be positive, got " + replicas);
+    }
+
+    final TopologyDescription description = topology.describe();
+    final Set<String> sourceTopics =
+        description.subtopologies().stream()
+            .flatMap(subtopology -> sourceTopicsOf(subtopology).stream())
+            .collect(toUnmodifiableSet());
+
+    final Map<String, Integer> partitionsByTopic = describePartitions(adminClient, sourceTopics);
+
+    int totalTasks = 0;
+    int subtopologyCount = 0;
+    for (final Subtopology subtopology : description.subtopologies()) {
+      subtopologyCount++;
+      final Set<String> subtopologyTopics = sourceTopicsOf(subtopology);
+
+      final int tasksForSubtopology =
+          subtopologyTopics.stream()
+              .mapToInt(topic -> partitionsByTopic.getOrDefault(topic, 0))
+              .max()
+              .orElse(0);
+
+      if (tasksForSubtopology == 0) {
+        logger.warn(
+            "Sub-topology has no resolvable partitions; topics={}. Pod restart will be needed once topics exist.",
+            subtopologyTopics);
+      }
+      totalTasks += tasksForSubtopology;
+    }
+
+    final int threads = totalTasks == 0 ? 1 : (int) Math.ceil((double) totalTasks / replicas);
+    logger.info(
+        "Dynamic num.stream.threads: totalTasks={} across {} sub-topologies, replicas={}, computed={}",
+        totalTasks,
+        subtopologyCount,
+        replicas,
+        threads);
+    return threads;
+  }
+
+  private Map<String, Integer> describePartitions(
+      final AdminClient adminClient, final Set<String> topics) {
+    if (topics.isEmpty()) {
+      return Map.of();
+    }
+    final DescribeTopicsResult result = adminClient.describeTopics(topics);
+    final Map<String, Integer> partitions = new HashMap<>();
+    for (final Entry<String, KafkaFuture<TopicDescription>> entry :
+        result.topicNameValues().entrySet()) {
+      try {
+        final TopicDescription description =
+            entry.getValue().get(DESCRIBE_TOPICS_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        partitions.put(entry.getKey(), description.partitions().size());
+      } catch (final ExecutionException executionException) {
+        if (executionException.getCause() instanceof UnknownTopicOrPartitionException) {
+          logger.warn(
+              "Topic absent on broker: {}. Treating as 0 partitions; restart needed once created.",
+              entry.getKey());
+          partitions.put(entry.getKey(), 0);
+        } else {
+          throw new RuntimeException(
+              "Failed to describe topic " + entry.getKey(), executionException);
+        }
+      } catch (final InterruptedException interruptedException) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(
+            "Interrupted while describing topic " + entry.getKey(), interruptedException);
+      } catch (final TimeoutException timeoutException) {
+        throw new RuntimeException(
+            "Timed out describing topic " + entry.getKey(), timeoutException);
+      }
+    }
+    return Map.copyOf(partitions);
+  }
+}

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
@@ -3,6 +3,7 @@ package org.hypertrace.core.kafkastreams.framework.threading;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.function.IntSupplier;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.streams.Topology;
@@ -27,16 +28,19 @@ public class StreamThreadsCountResolver {
 
   private final DynamicStreamThreadsCountCalculator calculator;
   private final IntSupplier replicaCountSupplier;
+  private final Function<Properties, AdminClient> adminClientFactory;
 
   public StreamThreadsCountResolver(final IntSupplier replicaCountSupplier) {
-    this(new DynamicStreamThreadsCountCalculator(), replicaCountSupplier);
+    this(new DynamicStreamThreadsCountCalculator(), replicaCountSupplier, AdminClient::create);
   }
 
-  StreamThreadsCountResolver(
+  public StreamThreadsCountResolver(
       final DynamicStreamThreadsCountCalculator calculator,
-      final IntSupplier replicaCountSupplier) {
+      final IntSupplier replicaCountSupplier,
+      final Function<Properties, AdminClient> adminClientFactory) {
     this.calculator = calculator;
     this.replicaCountSupplier = replicaCountSupplier;
+    this.adminClientFactory = adminClientFactory;
   }
 
   /**
@@ -56,7 +60,8 @@ public class StreamThreadsCountResolver {
   public int resolve(final Topology topology, final Map<String, Object> streamsProperties) {
     try {
       final int replicas = requirePositiveReplicaCount();
-      try (final AdminClient adminClient = AdminClient.create(toProperties(streamsProperties))) {
+      try (final AdminClient adminClient =
+          adminClientFactory.apply(toProperties(streamsProperties))) {
         return calculator.compute(topology, adminClient, replicas);
       }
     } catch (final RuntimeException runtimeException) {

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
@@ -1,0 +1,99 @@
+package org.hypertrace.core.kafkastreams.framework.threading;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.IntSupplier;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.streams.Topology;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves a concrete {@code num.stream.threads} value when the application has configured the
+ * {@link #DYNAMIC_SENTINEL} sentinel. Bridges the topology + AdminClient to the {@link
+ * DynamicStreamThreadsCountCalculator} and falls back to {@link #FALLBACK_NUM_STREAM_THREADS} when
+ * resolution fails.
+ *
+ * <p>The replica count is supplied externally — applications typically wire it from a {@code
+ * REPLICA_COUNT} environment variable injected by the deployment template.
+ */
+public class StreamThreadsCountResolver {
+
+  public static final String DYNAMIC_SENTINEL = "DYNAMIC";
+  static final int FALLBACK_NUM_STREAM_THREADS = 8;
+
+  private static final Logger logger = LoggerFactory.getLogger(StreamThreadsCountResolver.class);
+
+  private final DynamicStreamThreadsCountCalculator calculator;
+  private final IntSupplier replicaCountSupplier;
+
+  public StreamThreadsCountResolver(final IntSupplier replicaCountSupplier) {
+    this(new DynamicStreamThreadsCountCalculator(), replicaCountSupplier);
+  }
+
+  StreamThreadsCountResolver(
+      final DynamicStreamThreadsCountCalculator calculator,
+      final IntSupplier replicaCountSupplier) {
+    this.calculator = calculator;
+    this.replicaCountSupplier = replicaCountSupplier;
+  }
+
+  /**
+   * Returns true if the {@code num.stream.threads} value in the given streams properties is the
+   * dynamic sentinel and should be resolved by this class.
+   */
+  public static boolean isDynamic(final Map<String, Object> streamsProperties) {
+    final Object value =
+        streamsProperties.get(org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG);
+    return value != null && DYNAMIC_SENTINEL.equals(String.valueOf(value));
+  }
+
+  /**
+   * Resolve a concrete thread count for the given topology. Returns {@link
+   * #FALLBACK_NUM_STREAM_THREADS} on any failure so the application can still start.
+   */
+  public int resolve(final Topology topology, final Map<String, Object> streamsProperties) {
+    try {
+      final int replicas = requirePositiveReplicaCount();
+      try (final AdminClient adminClient = AdminClient.create(toProperties(streamsProperties))) {
+        return calculator.compute(topology, adminClient, replicas);
+      }
+    } catch (final RuntimeException runtimeException) {
+      logger.error(
+          "Failed to compute dynamic num.stream.threads; falling back to {}",
+          FALLBACK_NUM_STREAM_THREADS,
+          runtimeException);
+      return FALLBACK_NUM_STREAM_THREADS;
+    }
+  }
+
+  /**
+   * Convenience adapter — given an {@code Optional<Integer>} replica-count source (the common
+   * config-loaded shape), produce a supplier that this resolver accepts.
+   */
+  public static IntSupplier optionalReplicaCount(final Optional<Integer> replicaCount) {
+    return () ->
+        replicaCount.orElseThrow(
+            () -> new IllegalStateException("replica.count is not configured"));
+  }
+
+  private static Properties toProperties(final Map<String, Object> streamsProperties) {
+    final Properties properties = new Properties();
+    streamsProperties.forEach(
+        (key, value) -> {
+          if (value != null) {
+            properties.put(key, value);
+          }
+        });
+    return properties;
+  }
+
+  private int requirePositiveReplicaCount() {
+    final int replicas = replicaCountSupplier.getAsInt();
+    if (replicas <= 0) {
+      throw new IllegalStateException("replica.count must be positive, got " + replicas);
+    }
+    return replicas;
+  }
+}

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
@@ -17,12 +17,16 @@ import org.slf4j.LoggerFactory;
  * resolution fails.
  *
  * <p>The replica count is supplied externally — applications typically wire it from a {@code
- * REPLICA_COUNT} environment variable injected by the deployment template.
+ * REPLICA_COUNT} environment variable injected by the deployment template. A non-positive value
+ * (zero, negative, or unset) falls back to {@link #FALLBACK_NUM_STREAM_THREADS}.
  */
 public class StreamThreadsCountResolver {
 
   public static final String DYNAMIC_SENTINEL = "DYNAMIC";
-  static final int FALLBACK_NUM_STREAM_THREADS = 8;
+
+  // Reasonable default for current Hypertrace Kafka Streams apps. Apps that need a different
+  // value should configure a numeric num.stream.threads explicitly instead of using DYNAMIC.
+  public static final int FALLBACK_NUM_STREAM_THREADS = 8;
 
   private static final Logger logger = LoggerFactory.getLogger(StreamThreadsCountResolver.class);
 
@@ -55,15 +59,21 @@ public class StreamThreadsCountResolver {
 
   /**
    * Resolve a concrete thread count for the given topology. Returns {@link
-   * #FALLBACK_NUM_STREAM_THREADS} on any failure so the application can still start.
+   * #FALLBACK_NUM_STREAM_THREADS} when prerequisites are missing (non-positive replica count) or
+   * the AdminClient/calculator call fails, so the application can still start.
    */
   public int resolve(final Topology topology, final Map<String, Object> streamsProperties) {
-    try {
-      final int replicas = requirePositiveReplicaCount();
-      try (final AdminClient adminClient =
-          adminClientFactory.apply(toProperties(streamsProperties))) {
-        return calculator.compute(topology, adminClient, replicas);
-      }
+    final int replicas = replicaCountSupplier.getAsInt();
+    if (replicas <= 0) {
+      logger.warn(
+          "replica.count is non-positive ({}); falling back to {} stream threads",
+          replicas,
+          FALLBACK_NUM_STREAM_THREADS);
+      return FALLBACK_NUM_STREAM_THREADS;
+    }
+    try (final AdminClient adminClient =
+        adminClientFactory.apply(toProperties(streamsProperties))) {
+      return calculator.compute(topology, adminClient, replicas);
     } catch (final RuntimeException runtimeException) {
       logger.error(
           "Failed to compute dynamic num.stream.threads; falling back to {}",
@@ -75,12 +85,11 @@ public class StreamThreadsCountResolver {
 
   /**
    * Convenience adapter — given an {@code Optional<Integer>} replica-count source (the common
-   * config-loaded shape), produce a supplier that this resolver accepts.
+   * config-loaded shape), produce a supplier that yields the value when present and {@code 0} when
+   * absent (treated as a fallback signal by {@link #resolve}).
    */
   public static IntSupplier optionalReplicaCount(final Optional<Integer> replicaCount) {
-    return () ->
-        replicaCount.orElseThrow(
-            () -> new IllegalStateException("replica.count is not configured"));
+    return () -> replicaCount.orElse(0);
   }
 
   private static Properties toProperties(final Map<String, Object> streamsProperties) {
@@ -92,13 +101,5 @@ public class StreamThreadsCountResolver {
           }
         });
     return properties;
-  }
-
-  private int requirePositiveReplicaCount() {
-    final int replicas = replicaCountSupplier.getAsInt();
-    if (replicas <= 0) {
-      throw new IllegalStateException("replica.count must be positive, got " + replicas);
-    }
-    return replicas;
   }
 }

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
@@ -12,22 +12,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Resolves a concrete {@code num.stream.threads} value when the application has configured the
- * {@link #DYNAMIC_SENTINEL} sentinel. Bridges the topology + AdminClient to the {@link
- * DynamicStreamThreadsCountCalculator} and falls back to {@link #FALLBACK_NUM_STREAM_THREADS} when
- * resolution fails.
+ * Resolves a concrete {@code num.stream.threads} value for an app that has opted into dynamic
+ * thread sizing. Bridges the topology + AdminClient to the {@link
+ * DynamicStreamThreadsCountCalculator} and returns {@link OptionalInt#empty()} when resolution
+ * cannot produce a meaningful value — the caller keeps the configured numeric {@code
+ * num.stream.threads}.
  *
  * <p>The replica count is supplied externally — applications typically wire it from a {@code
  * REPLICA_COUNT} environment variable injected by the deployment template. A non-positive value
- * (zero, negative, or unset) falls back to {@link #FALLBACK_NUM_STREAM_THREADS}.
+ * (zero, negative, or unset) yields {@link OptionalInt#empty()}.
  */
 public class StreamThreadsCountResolver {
-
-  public static final String DYNAMIC_SENTINEL = "DYNAMIC";
-
-  // Reasonable default for current Hypertrace Kafka Streams apps. Apps that need a different
-  // value should configure a numeric num.stream.threads explicitly instead of using DYNAMIC.
-  public static final int FALLBACK_NUM_STREAM_THREADS = 8;
 
   private static final Logger logger = LoggerFactory.getLogger(StreamThreadsCountResolver.class);
 
@@ -49,20 +44,10 @@ public class StreamThreadsCountResolver {
   }
 
   /**
-   * Returns true if the {@code num.stream.threads} value in the given streams properties is the
-   * dynamic sentinel and should be resolved by this class.
-   */
-  public static boolean isDynamic(final Map<String, Object> streamsProperties) {
-    final Object value =
-        streamsProperties.get(org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG);
-    return value != null && DYNAMIC_SENTINEL.equals(String.valueOf(value));
-  }
-
-  /**
    * Resolve a thread count for the given topology. Returns {@link OptionalInt#empty()} when
    * prerequisites are missing (non-positive replica count), the topology is unsupported (regex
-   * sources), or the AdminClient/calculator call fails — the caller substitutes its fallback so the
-   * application can still start.
+   * sources), or the AdminClient/calculator call fails — the caller keeps the configured numeric
+   * {@code num.stream.threads} so the application can still start with a sane value.
    */
   public OptionalInt resolve(final Topology topology, final Map<String, Object> streamsProperties) {
     final int replicas = replicaCountSupplier.getAsInt();
@@ -84,7 +69,7 @@ public class StreamThreadsCountResolver {
   /**
    * Convenience adapter — given an {@code Optional<Integer>} replica-count source (the common
    * config-loaded shape), produce a supplier that yields the value when present and {@code 0} when
-   * absent (treated as a fallback signal by {@link #resolve}).
+   * absent (treated as a "skip dynamic resolution" signal by {@link #resolve}).
    */
   public static IntSupplier optionalReplicaCount(final Optional<Integer> replicaCount) {
     return () -> replicaCount.orElse(0);

--- a/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
+++ b/kafka-streams-framework/src/main/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolver.java
@@ -2,6 +2,7 @@ package org.hypertrace.core.kafkastreams.framework.threading;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
@@ -58,28 +59,25 @@ public class StreamThreadsCountResolver {
   }
 
   /**
-   * Resolve a concrete thread count for the given topology. Returns {@link
-   * #FALLBACK_NUM_STREAM_THREADS} when prerequisites are missing (non-positive replica count) or
-   * the AdminClient/calculator call fails, so the application can still start.
+   * Resolve a thread count for the given topology. Returns {@link OptionalInt#empty()} when
+   * prerequisites are missing (non-positive replica count), the topology is unsupported (regex
+   * sources), or the AdminClient/calculator call fails — the caller substitutes its fallback so the
+   * application can still start.
    */
-  public int resolve(final Topology topology, final Map<String, Object> streamsProperties) {
+  public OptionalInt resolve(final Topology topology, final Map<String, Object> streamsProperties) {
     final int replicas = replicaCountSupplier.getAsInt();
     if (replicas <= 0) {
-      logger.warn(
-          "replica.count is non-positive ({}); falling back to {} stream threads",
-          replicas,
-          FALLBACK_NUM_STREAM_THREADS);
-      return FALLBACK_NUM_STREAM_THREADS;
+      logger.warn("replica.count is non-positive ({}); skipping dynamic resolution", replicas);
+      return OptionalInt.empty();
     }
     try (final AdminClient adminClient =
         adminClientFactory.apply(toProperties(streamsProperties))) {
       return calculator.compute(topology, adminClient, replicas);
     } catch (final RuntimeException runtimeException) {
       logger.error(
-          "Failed to compute dynamic num.stream.threads; falling back to {}",
-          FALLBACK_NUM_STREAM_THREADS,
+          "Failed to compute dynamic num.stream.threads; skipping dynamic resolution",
           runtimeException);
-      return FALLBACK_NUM_STREAM_THREADS;
+      return OptionalInt.empty();
     }
   }
 

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
@@ -4,14 +4,17 @@ import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.typesafe.config.Config;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.TestInputTopic;
@@ -19,6 +22,7 @@ import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.hypertrace.core.kafkastreams.framework.rocksdb.BoundedMemoryConfigSetter;
+import org.hypertrace.core.kafkastreams.framework.threading.StreamThreadsCountResolver;
 import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,5 +87,54 @@ public class SampleAppTest {
         baseStreamsConfig.get(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG),
         is(LogAndContinueExceptionHandler.class));
     assertThat(baseStreamsConfig.get(producerPrefix(ACKS_CONFIG)), is("all"));
+  }
+
+  // Verifies the fix for "DYNAMIC sentinel could leak to Kafka Streams config when no resolver is
+  // wired up" — without resolver override, the framework must replace DYNAMIC with the integer
+  // fallback so Kafka Streams receives a parseable value.
+  @Test
+  public void dynamicWithoutResolverFallsBackToEight() {
+    SampleApp dynamicApp =
+        new SampleApp(ConfigClientFactory.getClient()) {
+          @Override
+          public Map<String, Object> getStreamsConfig(Config jobConfig) {
+            Map<String, Object> properties = super.getStreamsConfig(jobConfig);
+            properties.put(NUM_STREAM_THREADS_CONFIG, StreamThreadsCountResolver.DYNAMIC_SENTINEL);
+            return properties;
+          }
+        };
+
+    dynamicApp.doInit();
+
+    assertThat(
+        dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG),
+        is(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS));
+  }
+
+  // Verifies the fix for "exception while obtaining the resolver should not leak DYNAMIC" — when
+  // getStreamThreadsCountResolver() throws, the framework must catch and fall back to the integer
+  // default rather than letting the literal sentinel reach Kafka Streams.
+  @Test
+  public void dynamicWithThrowingResolverFallsBackToEight() {
+    SampleApp dynamicApp =
+        new SampleApp(ConfigClientFactory.getClient()) {
+          @Override
+          public Map<String, Object> getStreamsConfig(Config jobConfig) {
+            Map<String, Object> properties = super.getStreamsConfig(jobConfig);
+            properties.put(NUM_STREAM_THREADS_CONFIG, StreamThreadsCountResolver.DYNAMIC_SENTINEL);
+            return properties;
+          }
+
+          @Override
+          protected Optional<StreamThreadsCountResolver> getStreamThreadsCountResolver() {
+            throw new RuntimeException("simulated wiring failure");
+          }
+        };
+
+    dynamicApp.doInit();
+
+    assertThat(
+        dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG),
+        is(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS));
   }
 }

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
@@ -93,39 +93,43 @@ public class SampleAppTest {
     assertThat(baseStreamsConfig.get(producerPrefix(ACKS_CONFIG)), is("all"));
   }
 
-  // Verifies the fix for "DYNAMIC sentinel could leak to Kafka Streams config when no resolver is
-  // wired up" — without resolver override, the framework must replace DYNAMIC with the integer
-  // fallback so Kafka Streams receives a parseable value.
+  // No resolver wired up → framework must keep the configured num.stream.threads (the configured
+  // value is the fallback by definition) and strip the framework-only flag before it reaches
+  // Kafka Streams.
   @Test
-  public void dynamicWithoutResolverFallsBackToEight() {
+  public void dynamicWithoutResolverKeepsConfiguredValue() {
+    final Object configuredThreads = sampleApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG);
+
     SampleApp dynamicApp =
         new SampleApp(ConfigClientFactory.getClient()) {
           @Override
           public Map<String, Object> getStreamsConfig(Config jobConfig) {
             Map<String, Object> properties = super.getStreamsConfig(jobConfig);
-            properties.put(NUM_STREAM_THREADS_CONFIG, StreamThreadsCountResolver.DYNAMIC_SENTINEL);
+            properties.put(KafkaStreamsApp.DYNAMIC_NUM_STREAM_THREADS_CONFIG, true);
             return properties;
           }
         };
 
     dynamicApp.doInit();
 
+    assertThat(dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG), is(configuredThreads));
     assertThat(
-        dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG),
-        is(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS));
+        dynamicApp.streamsConfig.containsKey(KafkaStreamsApp.DYNAMIC_NUM_STREAM_THREADS_CONFIG),
+        is(false));
   }
 
-  // Pattern-source topology: calculator returns OptionalInt.empty() because regex subscriptions
-  // can't be enumerated up-front against the broker. The framework must substitute the integer
-  // fallback so Kafka Streams gets a parseable value (not the literal "DYNAMIC").
+  // Pattern-source topology: calculator returns OptionalInt.empty(). Configured num.stream.threads
+  // flows through unchanged.
   @Test
-  public void dynamicWithPatternSourceFallsBackToEight() {
+  public void dynamicWithPatternSourceKeepsConfiguredValue() {
+    final Object configuredThreads = sampleApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG);
+
     SampleApp dynamicApp =
         new SampleApp(ConfigClientFactory.getClient()) {
           @Override
           public Map<String, Object> getStreamsConfig(Config jobConfig) {
             Map<String, Object> properties = super.getStreamsConfig(jobConfig);
-            properties.put(NUM_STREAM_THREADS_CONFIG, StreamThreadsCountResolver.DYNAMIC_SENTINEL);
+            properties.put(KafkaStreamsApp.DYNAMIC_NUM_STREAM_THREADS_CONFIG, true);
             return properties;
           }
 
@@ -148,22 +152,20 @@ public class SampleAppTest {
 
     dynamicApp.doInit();
 
-    assertThat(
-        dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG),
-        is(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS));
+    assertThat(dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG), is(configuredThreads));
   }
 
-  // Verifies the fix for "exception while obtaining the resolver should not leak DYNAMIC" — when
-  // getStreamThreadsCountResolver() throws, the framework must catch and fall back to the integer
-  // default rather than letting the literal sentinel reach Kafka Streams.
+  // Resolver throws → configured num.stream.threads flows through unchanged.
   @Test
-  public void dynamicWithThrowingResolverFallsBackToEight() {
+  public void dynamicWithThrowingResolverKeepsConfiguredValue() {
+    final Object configuredThreads = sampleApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG);
+
     SampleApp dynamicApp =
         new SampleApp(ConfigClientFactory.getClient()) {
           @Override
           public Map<String, Object> getStreamsConfig(Config jobConfig) {
             Map<String, Object> properties = super.getStreamsConfig(jobConfig);
-            properties.put(NUM_STREAM_THREADS_CONFIG, StreamThreadsCountResolver.DYNAMIC_SENTINEL);
+            properties.put(KafkaStreamsApp.DYNAMIC_NUM_STREAM_THREADS_CONFIG, true);
             return properties;
           }
 
@@ -175,8 +177,6 @@ public class SampleAppTest {
 
     dynamicApp.doInit();
 
-    assertThat(
-        dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG),
-        is(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS));
+    assertThat(dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG), is(configuredThreads));
   }
 }

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/SampleAppTest.java
@@ -16,11 +16,15 @@ import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
 import org.hypertrace.core.kafkastreams.framework.rocksdb.BoundedMemoryConfigSetter;
 import org.hypertrace.core.kafkastreams.framework.threading.StreamThreadsCountResolver;
 import org.hypertrace.core.serviceframework.config.ConfigClientFactory;
@@ -101,6 +105,44 @@ public class SampleAppTest {
             Map<String, Object> properties = super.getStreamsConfig(jobConfig);
             properties.put(NUM_STREAM_THREADS_CONFIG, StreamThreadsCountResolver.DYNAMIC_SENTINEL);
             return properties;
+          }
+        };
+
+    dynamicApp.doInit();
+
+    assertThat(
+        dynamicApp.streamsConfig.get(NUM_STREAM_THREADS_CONFIG),
+        is(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS));
+  }
+
+  // Pattern-source topology: calculator returns OptionalInt.empty() because regex subscriptions
+  // can't be enumerated up-front against the broker. The framework must substitute the integer
+  // fallback so Kafka Streams gets a parseable value (not the literal "DYNAMIC").
+  @Test
+  public void dynamicWithPatternSourceFallsBackToEight() {
+    SampleApp dynamicApp =
+        new SampleApp(ConfigClientFactory.getClient()) {
+          @Override
+          public Map<String, Object> getStreamsConfig(Config jobConfig) {
+            Map<String, Object> properties = super.getStreamsConfig(jobConfig);
+            properties.put(NUM_STREAM_THREADS_CONFIG, StreamThreadsCountResolver.DYNAMIC_SENTINEL);
+            return properties;
+          }
+
+          @Override
+          public StreamsBuilder buildTopology(
+              Map<String, Object> streamsConfig,
+              StreamsBuilder streamsBuilder,
+              Map<String, KStream<?, ?>> sourceStreams) {
+            streamsBuilder.stream(
+                    Pattern.compile("input-.*"), Consumed.with(Serdes.String(), Serdes.String()))
+                .foreach((key, value) -> {});
+            return streamsBuilder;
+          }
+
+          @Override
+          protected Optional<StreamThreadsCountResolver> getStreamThreadsCountResolver() {
+            return Optional.of(new StreamThreadsCountResolver(() -> 8));
           }
         };
 

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculatorTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculatorTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
@@ -44,7 +46,7 @@ class DynamicStreamThreadsCountCalculatorTest {
     final Topology topology = topologyForSubtopologies(Set.of("topic-a"));
     stubPartitions(Map.of("topic-a", 30));
 
-    assertEquals(4, calculator.compute(topology, adminClient, 8));
+    assertEquals(OptionalInt.of(4), calculator.compute(topology, adminClient, 8));
   }
 
   @Test
@@ -52,7 +54,7 @@ class DynamicStreamThreadsCountCalculatorTest {
     final Topology topology = topologyForSubtopologies(Set.of("topic-a"), Set.of("topic-b"));
     stubPartitions(Map.of("topic-a", 10, "topic-b", 20));
 
-    assertEquals(4, calculator.compute(topology, adminClient, 8));
+    assertEquals(OptionalInt.of(4), calculator.compute(topology, adminClient, 8));
   }
 
   @Test
@@ -60,7 +62,7 @@ class DynamicStreamThreadsCountCalculatorTest {
     final Topology topology = topologyForSubtopologies(Set.of("topic-a"), Set.of("topic-missing"));
     stubPartitions(Map.of("topic-a", 16, "topic-missing", ABSENT));
 
-    assertEquals(2, calculator.compute(topology, adminClient, 8));
+    assertEquals(OptionalInt.of(2), calculator.compute(topology, adminClient, 8));
   }
 
   @Test
@@ -78,7 +80,20 @@ class DynamicStreamThreadsCountCalculatorTest {
     final Topology topology = topologyForSubtopologies(Set.of("topic-a"));
     stubPartitions(Map.of("topic-a", ABSENT));
 
-    assertEquals(1, calculator.compute(topology, adminClient, 8));
+    assertEquals(OptionalInt.of(1), calculator.compute(topology, adminClient, 8));
+  }
+
+  // Regex/pattern subscriptions cannot be enumerated up-front against the broker, so dynamic
+  // sizing would silently under-count tasks. Calculator must signal "not applicable" via empty
+  // so the caller falls back to its configured default.
+  @Test
+  void patternSubscriptionReturnsEmpty() {
+    final StreamsBuilder builder = new StreamsBuilder();
+    builder.stream(Pattern.compile("topic-.*"), Consumed.with(Serdes.String(), Serdes.String()))
+        .foreach((key, value) -> {});
+    final Topology topology = builder.build();
+
+    assertEquals(OptionalInt.empty(), calculator.compute(topology, adminClient, 8));
   }
 
   @SafeVarargs

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculatorTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculatorTest.java
@@ -75,12 +75,13 @@ class DynamicStreamThreadsCountCalculatorTest {
         IllegalArgumentException.class, () -> calculator.compute(topology, adminClient, -1));
   }
 
+  // No resolvable partitions -> caller keeps the configured num.stream.threads as-is.
   @Test
-  void totalTasksZeroReturnsOne() {
+  void totalTasksZeroReturnsEmpty() {
     final Topology topology = topologyForSubtopologies(Set.of("topic-a"));
     stubPartitions(Map.of("topic-a", ABSENT));
 
-    assertEquals(OptionalInt.of(1), calculator.compute(topology, adminClient, 8));
+    assertEquals(OptionalInt.empty(), calculator.compute(topology, adminClient, 8));
   }
 
   // Regex/pattern subscriptions cannot be enumerated up-front against the broker, so dynamic

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculatorTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/DynamicStreamThreadsCountCalculatorTest.java
@@ -1,0 +1,117 @@
+package org.hypertrace.core.kafkastreams.framework.threading;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DynamicStreamThreadsCountCalculatorTest {
+
+  private static final int ABSENT = -1;
+
+  private final DynamicStreamThreadsCountCalculator calculator =
+      new DynamicStreamThreadsCountCalculator();
+
+  @Mock private AdminClient adminClient;
+
+  @Test
+  void singleSubtopologyWithThirtyPartitionsAndEightReplicasGivesFourThreads() {
+    final Topology topology = topologyForSubtopologies(Set.of("topic-a"));
+    stubPartitions(Map.of("topic-a", 30));
+
+    assertEquals(4, calculator.compute(topology, adminClient, 8));
+  }
+
+  @Test
+  void twoSubtopologiesAreSummedThenDividedByReplicas() {
+    final Topology topology = topologyForSubtopologies(Set.of("topic-a"), Set.of("topic-b"));
+    stubPartitions(Map.of("topic-a", 10, "topic-b", 20));
+
+    assertEquals(4, calculator.compute(topology, adminClient, 8));
+  }
+
+  @Test
+  void absentTopicCountsAsZeroPartitions() {
+    final Topology topology = topologyForSubtopologies(Set.of("topic-a"), Set.of("topic-missing"));
+    stubPartitions(Map.of("topic-a", 16, "topic-missing", ABSENT));
+
+    assertEquals(2, calculator.compute(topology, adminClient, 8));
+  }
+
+  @Test
+  void zeroOrNegativeReplicasThrows() {
+    final Topology topology = topologyForSubtopologies(Set.of("topic-a"));
+
+    assertThrows(
+        IllegalArgumentException.class, () -> calculator.compute(topology, adminClient, 0));
+    assertThrows(
+        IllegalArgumentException.class, () -> calculator.compute(topology, adminClient, -1));
+  }
+
+  @Test
+  void totalTasksZeroReturnsOne() {
+    final Topology topology = topologyForSubtopologies(Set.of("topic-a"));
+    stubPartitions(Map.of("topic-a", ABSENT));
+
+    assertEquals(1, calculator.compute(topology, adminClient, 8));
+  }
+
+  @SafeVarargs
+  private static Topology topologyForSubtopologies(final Set<String>... topicsBySubtopology) {
+    final StreamsBuilder builder = new StreamsBuilder();
+    for (final Set<String> topics : topicsBySubtopology) {
+      for (final String topic : topics) {
+        builder.stream(topic, Consumed.with(Serdes.String(), Serdes.String()))
+            .foreach((key, value) -> {});
+      }
+    }
+    return builder.build();
+  }
+
+  private void stubPartitions(final Map<String, Integer> partitionsByTopic) {
+    final DescribeTopicsResult result = mock(DescribeTopicsResult.class);
+    final Map<String, KafkaFuture<TopicDescription>> futures = new HashMap<>();
+    partitionsByTopic.forEach(
+        (topic, partitionCount) -> futures.put(topic, futureFor(topic, partitionCount)));
+    when(result.topicNameValues()).thenReturn(futures);
+    when(adminClient.describeTopics(anySet())).thenReturn(result);
+  }
+
+  private static KafkaFuture<TopicDescription> futureFor(final String topic, final int partitions) {
+    if (partitions == ABSENT) {
+      final KafkaFutureImpl<TopicDescription> failed = new KafkaFutureImpl<>();
+      failed.completeExceptionally(new UnknownTopicOrPartitionException(topic));
+      return failed;
+    }
+    final List<TopicPartitionInfo> partitionInfos =
+        IntStream.range(0, partitions)
+            .mapToObj(index -> new TopicPartitionInfo(index, Node.noNode(), List.of(), List.of()))
+            .collect(toUnmodifiableList());
+    return KafkaFuture.completedFuture(new TopicDescription(topic, false, partitionInfos));
+  }
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
@@ -1,0 +1,107 @@
+package org.hypertrace.core.kafkastreams.framework.threading;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.IntSupplier;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StreamThreadsCountResolverTest {
+
+  @Mock private DynamicStreamThreadsCountCalculator calculator;
+
+  @Test
+  void calculatorThrowFallsBackToEight() {
+    final Topology topology = simpleTopology();
+    when(calculator.compute(eq(topology), any(), eq(8)))
+        .thenThrow(new RuntimeException("simulated broker outage"));
+    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, () -> 8);
+
+    final int resolved = resolver.resolve(topology, bootstrapProperties());
+
+    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+  }
+
+  @Test
+  void missingReplicaCountFallsBack() {
+    final IntSupplier missing = StreamThreadsCountResolver.optionalReplicaCount(Optional.empty());
+    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, missing);
+
+    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
+
+    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+  }
+
+  @Test
+  void zeroReplicaCountFallsBack() {
+    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, () -> 0);
+
+    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
+
+    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+  }
+
+  @Test
+  void negativeReplicaCountFallsBack() {
+    final StreamThreadsCountResolver resolver =
+        new StreamThreadsCountResolver(calculator, () -> -1);
+
+    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
+
+    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+  }
+
+  @Test
+  void delegatesToCalculatorWithConfiguredReplicas() {
+    final Topology topology = simpleTopology();
+    when(calculator.compute(eq(topology), any(), eq(8))).thenReturn(7);
+    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, () -> 8);
+
+    final int resolved = resolver.resolve(topology, bootstrapProperties());
+
+    assertEquals(7, resolved);
+  }
+
+  @Test
+  void isDynamicTrueWhenSentinelSet() {
+    assertEquals(
+        true,
+        StreamThreadsCountResolver.isDynamic(
+            Map.of(
+                StreamsConfig.NUM_STREAM_THREADS_CONFIG,
+                StreamThreadsCountResolver.DYNAMIC_SENTINEL)));
+  }
+
+  @Test
+  void isDynamicFalseForNumericValueOrAbsent() {
+    assertEquals(
+        false,
+        StreamThreadsCountResolver.isDynamic(Map.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 4)));
+    assertEquals(false, StreamThreadsCountResolver.isDynamic(Map.of()));
+  }
+
+  private static Topology simpleTopology() {
+    final StreamsBuilder builder = new StreamsBuilder();
+    builder.stream("topic-a", Consumed.with(Serdes.String(), Serdes.String()))
+        .foreach((key, value) -> {});
+    return builder.build();
+  }
+
+  private static Map<String, Object> bootstrapProperties() {
+    return Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+  }
+}

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.junit.jupiter.api.Test;
@@ -72,24 +71,6 @@ class StreamThreadsCountResolverTest {
     final StreamThreadsCountResolver resolver = resolverWith(() -> 8, adminClient);
 
     assertEquals(OptionalInt.of(4), resolver.resolve(simpleTopology(), bootstrapProperties()));
-  }
-
-  @Test
-  void isDynamicTrueWhenSentinelSet() {
-    assertEquals(
-        true,
-        StreamThreadsCountResolver.isDynamic(
-            Map.of(
-                StreamsConfig.NUM_STREAM_THREADS_CONFIG,
-                StreamThreadsCountResolver.DYNAMIC_SENTINEL)));
-  }
-
-  @Test
-  void isDynamicFalseForNumericValueOrAbsent() {
-    assertEquals(
-        false,
-        StreamThreadsCountResolver.isDynamic(Map.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 4)));
-    assertEquals(false, StreamThreadsCountResolver.isDynamic(Map.of()));
   }
 
   private static StreamThreadsCountResolver resolverWith(

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
@@ -1,37 +1,43 @@
 package org.hypertrace.core.kafkastreams.framework.threading;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Function;
 import java.util.function.IntSupplier;
+import java.util.stream.IntStream;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class StreamThreadsCountResolverTest {
-
-  @Mock private DynamicStreamThreadsCountCalculator calculator;
 
   @Test
   void calculatorThrowFallsBackToEight() {
-    final Topology topology = simpleTopology();
-    when(calculator.compute(eq(topology), any(), eq(8)))
+    final AdminClient adminClient = mock(AdminClient.class);
+    when(adminClient.describeTopics(anySet()))
         .thenThrow(new RuntimeException("simulated broker outage"));
-    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, () -> 8);
+    final StreamThreadsCountResolver resolver = resolverWith(() -> 8, adminClient);
 
-    final int resolved = resolver.resolve(topology, bootstrapProperties());
+    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
 
     assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
   }
@@ -39,7 +45,7 @@ class StreamThreadsCountResolverTest {
   @Test
   void missingReplicaCountFallsBack() {
     final IntSupplier missing = StreamThreadsCountResolver.optionalReplicaCount(Optional.empty());
-    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, missing);
+    final StreamThreadsCountResolver resolver = resolverWith(missing, mock(AdminClient.class));
 
     final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
 
@@ -48,7 +54,7 @@ class StreamThreadsCountResolverTest {
 
   @Test
   void zeroReplicaCountFallsBack() {
-    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, () -> 0);
+    final StreamThreadsCountResolver resolver = resolverWith(() -> 0, mock(AdminClient.class));
 
     final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
 
@@ -57,8 +63,7 @@ class StreamThreadsCountResolverTest {
 
   @Test
   void negativeReplicaCountFallsBack() {
-    final StreamThreadsCountResolver resolver =
-        new StreamThreadsCountResolver(calculator, () -> -1);
+    final StreamThreadsCountResolver resolver = resolverWith(() -> -1, mock(AdminClient.class));
 
     final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
 
@@ -67,13 +72,15 @@ class StreamThreadsCountResolverTest {
 
   @Test
   void delegatesToCalculatorWithConfiguredReplicas() {
-    final Topology topology = simpleTopology();
-    when(calculator.compute(eq(topology), any(), eq(8))).thenReturn(7);
-    final StreamThreadsCountResolver resolver = new StreamThreadsCountResolver(calculator, () -> 8);
+    // 30-partition source / 8 replicas -> ceil(30/8) = 4 threads. Real calculator computes this;
+    // only AdminClient (the external) is stubbed.
+    final AdminClient adminClient = mock(AdminClient.class);
+    stubPartitions(adminClient, Map.of("topic-a", 30));
+    final StreamThreadsCountResolver resolver = resolverWith(() -> 8, adminClient);
 
-    final int resolved = resolver.resolve(topology, bootstrapProperties());
+    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
 
-    assertEquals(7, resolved);
+    assertEquals(4, resolved);
   }
 
   @Test
@@ -94,6 +101,13 @@ class StreamThreadsCountResolverTest {
     assertEquals(false, StreamThreadsCountResolver.isDynamic(Map.of()));
   }
 
+  private static StreamThreadsCountResolver resolverWith(
+      final IntSupplier replicaCountSupplier, final AdminClient adminClient) {
+    final Function<Properties, AdminClient> factory = properties -> adminClient;
+    return new StreamThreadsCountResolver(
+        new DynamicStreamThreadsCountCalculator(), replicaCountSupplier, factory);
+  }
+
   private static Topology simpleTopology() {
     final StreamsBuilder builder = new StreamsBuilder();
     builder.stream("topic-a", Consumed.with(Serdes.String(), Serdes.String()))
@@ -103,5 +117,23 @@ class StreamThreadsCountResolverTest {
 
   private static Map<String, Object> bootstrapProperties() {
     return Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+  }
+
+  private static void stubPartitions(
+      final AdminClient adminClient, final Map<String, Integer> partitionsByTopic) {
+    final DescribeTopicsResult result = mock(DescribeTopicsResult.class);
+    final Map<String, KafkaFuture<TopicDescription>> futures = new HashMap<>();
+    partitionsByTopic.forEach(
+        (topic, partitionCount) -> futures.put(topic, futureFor(topic, partitionCount)));
+    when(result.topicNameValues()).thenReturn(futures);
+    when(adminClient.describeTopics(anySet())).thenReturn(result);
+  }
+
+  private static KafkaFuture<TopicDescription> futureFor(final String topic, final int partitions) {
+    final List<TopicPartitionInfo> partitionInfos =
+        IntStream.range(0, partitions)
+            .mapToObj(index -> new TopicPartitionInfo(index, Node.noNode(), List.of(), List.of()))
+            .collect(toUnmodifiableList());
+    return KafkaFuture.completedFuture(new TopicDescription(topic, false, partitionInfos));
   }
 }

--- a/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
+++ b/kafka-streams-framework/src/test/java/org/hypertrace/core/kafkastreams/framework/threading/StreamThreadsCountResolverTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
@@ -31,43 +32,35 @@ import org.junit.jupiter.api.Test;
 class StreamThreadsCountResolverTest {
 
   @Test
-  void calculatorThrowFallsBackToEight() {
+  void calculatorThrowReturnsEmpty() {
     final AdminClient adminClient = mock(AdminClient.class);
     when(adminClient.describeTopics(anySet()))
         .thenThrow(new RuntimeException("simulated broker outage"));
     final StreamThreadsCountResolver resolver = resolverWith(() -> 8, adminClient);
 
-    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
-
-    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+    assertEquals(OptionalInt.empty(), resolver.resolve(simpleTopology(), bootstrapProperties()));
   }
 
   @Test
-  void missingReplicaCountFallsBack() {
+  void missingReplicaCountReturnsEmpty() {
     final IntSupplier missing = StreamThreadsCountResolver.optionalReplicaCount(Optional.empty());
     final StreamThreadsCountResolver resolver = resolverWith(missing, mock(AdminClient.class));
 
-    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
-
-    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+    assertEquals(OptionalInt.empty(), resolver.resolve(simpleTopology(), bootstrapProperties()));
   }
 
   @Test
-  void zeroReplicaCountFallsBack() {
+  void zeroReplicaCountReturnsEmpty() {
     final StreamThreadsCountResolver resolver = resolverWith(() -> 0, mock(AdminClient.class));
 
-    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
-
-    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+    assertEquals(OptionalInt.empty(), resolver.resolve(simpleTopology(), bootstrapProperties()));
   }
 
   @Test
-  void negativeReplicaCountFallsBack() {
+  void negativeReplicaCountReturnsEmpty() {
     final StreamThreadsCountResolver resolver = resolverWith(() -> -1, mock(AdminClient.class));
 
-    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
-
-    assertEquals(StreamThreadsCountResolver.FALLBACK_NUM_STREAM_THREADS, resolved);
+    assertEquals(OptionalInt.empty(), resolver.resolve(simpleTopology(), bootstrapProperties()));
   }
 
   @Test
@@ -78,9 +71,7 @@ class StreamThreadsCountResolverTest {
     stubPartitions(adminClient, Map.of("topic-a", 30));
     final StreamThreadsCountResolver resolver = resolverWith(() -> 8, adminClient);
 
-    final int resolved = resolver.resolve(simpleTopology(), bootstrapProperties());
-
-    assertEquals(4, resolved);
+    assertEquals(OptionalInt.of(4), resolver.resolve(simpleTopology(), bootstrapProperties()));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Introduces a per-instance auto-sizing path for `num.stream.threads`. When an app opts in by (a) overriding `getStreamThreadsCountResolver()` and (b) setting `dynamic.num.stream.threads = true` in its streams config, the framework derives the right thread count from the topology's partition layout and the deployment's replica count — keeping every stream task active without idle threads or noisy under-allocation.

The new `threading` package contains:

- **`DynamicStreamThreadsCountCalculator`** — sums the maximum partition count across each sub-topology's source topics (one task per partition per sub-topology) and divides by the replica count to get per-instance threads. Returns `OptionalInt.empty()` when the topology contains a regex/pattern source or no source partitions are resolvable on the broker — caller keeps the configured value.
- **`StreamThreadsCountResolver`** — bridges topology + `AdminClient` to the calculator. Returns `OptionalInt.empty()` on any failure (broker outage, missing replica count, AdminClient errors) so the app keeps the configured `num.stream.threads`.

`KafkaStreamsApp` exposes:

- A new overrideable hook `getStreamThreadsCountResolver()` returning `Optional.empty()` by default. Apps that want auto-sizing override it.
- A new framework-only config key `KafkaStreamsApp.DYNAMIC_NUM_STREAM_THREADS_CONFIG = "dynamic.num.stream.threads"` (boolean). The framework reads and strips this flag before the config reaches Kafka Streams, so it never hits `StreamsConfig` validation.

## Why

Today every Hypertrace Kafka Streams app hardcodes `num.stream.threads` per-cluster in its Helm values. As topics grow partitions or as replica counts change, the hardcoded value drifts from the optimal — leading to idle threads or under-provisioned consumption. This change lets ops flip `dynamic.num.stream.threads = true` per-cluster and have the right number computed at startup based on actual broker state.

## Why a separate boolean flag (vs. a `"DYNAMIC"` sentinel on `num.stream.threads`)

Per review discussion (https://github.com/hypertrace/kafka-streams-framework/pull/119#discussion_r3354000676):

- **Type safety.** A string sentinel on `num.stream.threads` works only because nothing in the current pipeline constructs `StreamsConfig` from the map before `doInit()` substitutes the int. Any future caller that touches the map (validation, logging, a feature-flag read) would throw `ConfigException`. A separate boolean key removes that landmine.
- **No hardcoded static fallback.** With a sentinel, "DYNAMIC set but resolver returned empty" needs an arbitrary integer fallback (the prior PR used `8`, wrong for any app whose static value isn't 8). With the boolean flag, the configured numeric `num.stream.threads` *is* the fallback — by definition the value the app would have run with had they not opted in.
- **Dual opt-in preserved.** Service overrides `getStreamThreadsCountResolver()` AND config sets `dynamic.num.stream.threads = true`. Per-cluster rollout/rollback intact.

## Safety

This is a library change consumed by every Hypertrace Kafka Streams app. The flow is engineered to be invisible to apps that don't opt in:

- Apps that don't set `dynamic.num.stream.threads` (everyone today) take the same code path as before — `num.stream.threads` flows through unchanged.
- The entire `doInit()` body is wrapped in `try { ... } catch (Exception e) { log; System.exit(1); }` (existing envelope). Any unexpected failure is handled there.
- When the flag is `true` but resolution can't produce a value (no resolver, resolver throws, broker unreachable, regex source, replica count missing), the configured numeric `num.stream.threads` is left untouched.

## Other changes

- Fixes a typo'd `import Optional;` (missing `java.util.`) in `KafkaStreamsApp.java`.
- Adds `mockito-junit-jupiter` (via `commonLibs.mockito.junit`) so `@ExtendWith(MockitoExtension.class)` resolves.

## Rebase notes

Rebased onto post-BOM `main` (#120 merged as `94e63d8`). The conflict in `kafka-streams-framework/build.gradle.kts` was resolved by keeping the new `commonLibs.*` / `localLibs.*` form and routing the new mockito-junit dep through `commonLibs.mockito.junit`. Per-module `gradle.lockfile`s were regenerated via `./gradlew resolveAndLockAll --write-locks`.

## Test plan

- [x] Unit test: single sub-topology partition→threads math
- [x] Unit test: multi sub-topology summation
- [x] Unit test: absent topic counts as zero partitions
- [x] Unit test: zero/negative replicas throws (calculator)
- [x] Unit test: total tasks zero returns empty (configured value preserved)
- [x] Unit test: pattern subscription returns empty
- [x] Unit test: resolver returns empty on calculator throw / missing-zero-negative replica count
- [x] Unit test: resolver delegates to calculator with configured replicas
- [x] `SampleAppTest`: dynamic enabled with no resolver / pattern source / throwing resolver — all preserve configured `num.stream.threads` and strip the framework-only flag
- [x] `./gradlew clean build` green locally
- [ ] Reviewer to validate the safety guarantee for non-opted-in apps (no behavior change expected)
